### PR TITLE
Support multiple Harbors linked to one Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ make build
 ```
 
 ### Environment variables
+Below environment variables can be used instead of the corresponding flags. Easy when running the exporter in a container.
 
 ```
+HARBOR_INSTANCE
 HARBOR_URI
 HARBOR_USERNAME
 HARBOR_PASSWORD

--- a/harbor_exporter.go
+++ b/harbor_exporter.go
@@ -41,66 +41,18 @@ const (
 )
 
 var (
-	up = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "up"),
-		"Was the last query of harbor successful.",
-		nil, nil,
-	)
-	scanTotalCount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "scans_total"),
-		"metrics of the latest scan all process",
-		nil, nil,
-	)
-	scanCompletedCount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "scans_completed"),
-		"metrics of the latest scan all process",
-		nil, nil,
-	)
-	scanRequesterCount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "scans_requester"),
-		"metrics of the latest scan all process",
-		nil, nil,
-	)
-	projectCount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "project_count_total"),
-		"projects number relevant to the user",
-		[]string{"type"}, nil,
-	)
-	repoCount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "repo_count_total"),
-		"repositories number relevant to the user",
-		[]string{"type"}, nil,
-	)
-	quotasCount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "quotas_count_total"),
-		"quotas",
-		[]string{"type", "repo_name", "repo_id"}, nil,
-	)
-	quotasSize = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "quotas_size_bytes"),
-		"quotas",
-		[]string{"type", "repo_name", "repo_id"}, nil,
-	)
-	systemVolumes = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "system_volumes_bytes"),
-		"Get system volume info (total/free size).",
-		[]string{"storage"}, nil,
-	)
-	repositoriesPullCount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "repositories_pull_total"),
-		"Get public repositories which are accessed most.).",
-		[]string{"repo_name", "repo_id"}, nil,
-	)
-	repositoriesStarCount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "repositories_star_total"),
-		"Get public repositories which are accessed most.).",
-		[]string{"repo_name", "repo_id"}, nil,
-	)
-	repositoriesTagsCount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "repositories_tags_total"),
-		"Get public repositories which are accessed most.).",
-		[]string{"repo_name", "repo_id"}, nil,
-	)
+	up,
+	scanTotalCount,
+	scanCompletedCount,
+	scanRequesterCount,
+	projectCount,
+	repoCount,
+	quotasCount,
+	quotasSize,
+	systemVolumes,
+	repositoriesPullCount,
+	repositoriesStarCount,
+	repositoriesTagsCount *prometheus.Desc
 )
 
 type promHTTPLogger struct {
@@ -120,6 +72,7 @@ type Exporter struct {
 }
 
 type harborOpts struct {
+	instance string
 	uri      string
 	username string
 	password string
@@ -193,6 +146,69 @@ func NewExporter(opts harborOpts, logger log.Logger) (*Exporter, error) {
 		Transport: transport,
 	}
 	hc := HarborClient{client, opts, logger}
+
+	// Init Prometheus Descriptors
+	up = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "up"),
+		"Was the last query of harbor successful.",
+		nil, nil,
+	)
+	scanTotalCount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "scans_total"),
+		"metrics of the latest scan all process",
+		nil, nil,
+	)
+	scanCompletedCount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "scans_completed"),
+		"metrics of the latest scan all process",
+		nil, nil,
+	)
+	scanRequesterCount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "scans_requester"),
+		"metrics of the latest scan all process",
+		nil, nil,
+	)
+	projectCount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "project_count_total"),
+		"projects number relevant to the user",
+		[]string{"type"}, nil,
+	)
+	repoCount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "repo_count_total"),
+		"repositories number relevant to the user",
+		[]string{"type"}, nil,
+	)
+	quotasCount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "quotas_count_total"),
+		"quotas",
+		[]string{"type", "repo_name", "repo_id"}, nil,
+	)
+	quotasSize = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "quotas_size_bytes"),
+		"quotas",
+		[]string{"type", "repo_name", "repo_id"}, nil,
+	)
+	systemVolumes = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "system_volumes_bytes"),
+		"Get system volume info (total/free size).",
+		[]string{"storage"}, nil,
+	)
+	repositoriesPullCount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "repositories_pull_total"),
+		"Get public repositories which are accessed most.).",
+		[]string{"repo_name", "repo_id"}, nil,
+	)
+	repositoriesStarCount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "repositories_star_total"),
+		"Get public repositories which are accessed most.).",
+		[]string{"repo_name", "repo_id"}, nil,
+	)
+	repositoriesTagsCount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, opts.instance, "repositories_tags_total"),
+		"Get public repositories which are accessed most.).",
+		[]string{"repo_name", "repo_id"}, nil,
+	)
+
 	// Init our exporter.
 	return &Exporter{
 		client: hc,
@@ -249,6 +265,7 @@ func main() {
 
 		opts = harborOpts{}
 	)
+	kingpin.Flag("harbor.instance", "Logical name for the Harbor instance to monitor").Envar("HARBOR_INSTANCE").Default("").StringVar(&opts.instance)
 	kingpin.Flag("harbor.server", "HTTP API address of a harbor server or agent. (prefix with https:// to connect over HTTPS)").Envar("HARBOR_URI").Default("http://localhost:8500").StringVar(&opts.uri)
 	kingpin.Flag("harbor.username", "username").Envar("HARBOR_USERNAME").Default("admin").StringVar(&opts.username)
 	kingpin.Flag("harbor.password", "password").Envar("HARBOR_PASSWORD").Default("password").StringVar(&opts.password)

--- a/kubernetes/harbor-exporter.yaml
+++ b/kubernetes/harbor-exporter.yaml
@@ -43,17 +43,23 @@ spec:
           image: "c4po/harbor-exporter"
           imagePullPolicy: IfNotPresent
           env:
+##          necessary in case you monitor multiple Harbor instances in your Prometheus
+#            - name: HARBOR_INSTANCE
+#              value: my_harbor
             - name: HARBOR_URI
-              valueFrom:
-                configMapKeyRef:
-                  name: cover-harbor-core # change prefix to the name of your Helm release
-                  key: EXT_ENDPOINT
+##            name of the Service for harbor-core
+              value: prefix-harbor-core # change prefix to the name of your Helm release
+##            optionally use below construction to address the external endpoint of Harbor
+#              valueFrom:
+#                configMapKeyRef:
+#                  name: prefix-harbor-core # change prefix to the name of your Helm release
+#                  key: EXT_ENDPOINT
             - name: HARBOR_USERNAME
               value: "admin"
             - name: HARBOR_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: cover-harbor-core # change prefix to the name of your Helm release
+                  name: prefix-harbor-core # change prefix to the name of your Helm release
                   key: HARBOR_ADMIN_PASSWORD
 
           securityContext:


### PR DESCRIPTION
In case there are multiple Harbor instances that need to be monitored in the same Prometheus, the descriptors must get unique names.
This change adds the option harbor.instance (environment variable HARBOR_INSTANCE) that gives the possibility to do just that.
If the option is absent, then the descriptor names are the same as before.