### PR TITLE
Added metrics for replications

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ make build
 ./harbor_exporter [flags]
 ```
 
+To build a Docker image:
+
+```
+docker build . --tag <mytag>
+```
 
 ## Exported Metrics
 
@@ -28,6 +33,14 @@ make build
 |harbor_repositories_pull_total| |repo_id, repo_name|
 |harbor_repositories_star_total| |repo_id, repo_name|
 |harbor_repositories_tags_total| |repo_id, repo_name|
+|harbor_replication_status|status of the last execution of this replication policy: Succeed = 1, any other status = 0|repl_pol_name|
+|harbor_replications_total|number of replication tasks in total in the last execution of this replication policy|repl_pol_name|
+|harbor_replications_failed|number of replication tasks that failed in the last execution of this replication policy|repl_pol_name|
+|harbor_replications_succeed|number of replication tasks that completed successfully in the last execution of this replication policy|repl_pol_name|
+|harbor_replications_in_progress|number of replication tasks in progress in the last execution of this replication policy|repl_pol_name|
+|harbor_replications_stopped|number of tags for which the replication stopped in the last execution of this replication policy|repl_pol_name|
+
+_Note: when the harbor.instance flag is used, each metric name starts with `harbor_instancename_` instead of just `harbor_`._
 
 ### Flags
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ make dockerbuild
 |harbor_repositories_star_total| |repo_id, repo_name|
 |harbor_repositories_tags_total| |repo_id, repo_name|
 |harbor_replication_status|status of the last execution of this replication policy: Succeed = 1, any other status = 0|repl_pol_name|
-|harbor_replication_tasks|number of replication tasks in total and in various statuses in the last execution of this replication policy|repl_pol_name, type=[total, failed, succeed, in_progress, stopped]|
+|harbor_replication_tasks|number of replication tasks, with various results, in the latest execution of this replication policy|repl_pol_name, result=[failed, succeed, in_progress, stopped]|
 
 _Note: when the harbor.instance flag is used, each metric name starts with `harbor_instancename_` instead of just `harbor_`._
 

--- a/README.md
+++ b/README.md
@@ -25,20 +25,16 @@ make dockerbuild
 |harbor_scans_completed | | |
 |harbor_scans_total | | |
 |harbor_scans_requester | | |
-|harbor_project_count_total| |type=[private_project,public_project,total_project]|
-|harbor_repo_count_total| |type=[private_repo,public_repo,total_repo]|
-|harbor_quotas_count_total| |repo_id, repo_name, type=[hard,used]|
-|harbor_quotas_size_bytes| | repo_id, repo_name, type=[hard,used]|
-|harbor_system_volumes_bytes| |storage=[free,total]|
+|harbor_project_count_total| |type=[private_project, public_project, total_project]|
+|harbor_repo_count_total| |type=[private_repo, public_repo, total_repo]|
+|harbor_quotas_count_total| |repo_id, repo_name, type=[hard, used]|
+|harbor_quotas_size_bytes| | repo_id, repo_name, type=[hard, used]|
+|harbor_system_volumes_bytes| |storage=[free, total]|
 |harbor_repositories_pull_total| |repo_id, repo_name|
 |harbor_repositories_star_total| |repo_id, repo_name|
 |harbor_repositories_tags_total| |repo_id, repo_name|
 |harbor_replication_status|status of the last execution of this replication policy: Succeed = 1, any other status = 0|repl_pol_name|
-|harbor_replications_total|number of replication tasks in total in the last execution of this replication policy|repl_pol_name|
-|harbor_replications_failed|number of replication tasks that failed in the last execution of this replication policy|repl_pol_name|
-|harbor_replications_succeed|number of replication tasks that completed successfully in the last execution of this replication policy|repl_pol_name|
-|harbor_replications_in_progress|number of replication tasks in progress in the last execution of this replication policy|repl_pol_name|
-|harbor_replications_stopped|number of tags for which the replication stopped in the last execution of this replication policy|repl_pol_name|
+|harbor_replication_tasks|number of replication tasks in total and in various statuses in the last execution of this replication policy|repl_pol_name, type=[total, failed, succeed, in_progress, stopped]|
 
 _Note: when the harbor.instance flag is used, each metric name starts with `harbor_instancename_` instead of just `harbor_`._
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ make build
 To build a Docker image:
 
 ```
-docker build . --tag <mytag>
+make dockerbuild
 ```
 
 ## Exported Metrics

--- a/harbor_exporter.go
+++ b/harbor_exporter.go
@@ -221,8 +221,8 @@ func NewExporter(opts harborOpts, logger log.Logger) (*Exporter, error) {
 	)
 	replicationTasks = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, opts.instance, "replication_tasks"),
-		"Get number of replication tasks in total and in various statuses in the last execution of this replication policy.",
-		[]string{"repl_pol_name", "type"}, nil,
+		"Get number of replication tasks, with various results, in the latest execution of this replication policy.",
+		[]string{"repl_pol_name", "result"}, nil,
 	)
 
 	// Init our exporter.

--- a/metrics_replications.go
+++ b/metrics_replications.go
@@ -54,19 +54,19 @@ func (e *Exporter) collectReplicationsMetric(ch chan<- prometheus.Metric) bool {
 				replicationStatus, prometheus.GaugeValue, replStatus, policyName,
 			)
 			ch <- prometheus.MustNewConstMetric(
-				replicationsTotal, prometheus.GaugeValue, data[i].Total, policyName,
+				replicationTasks, prometheus.GaugeValue, data[i].Total, policyName, "total",
 			)
 			ch <- prometheus.MustNewConstMetric(
-				replicationsFailed, prometheus.GaugeValue, data[i].Failed, policyName,
+				replicationTasks, prometheus.GaugeValue, data[i].Failed, policyName, "failed",
 			)
 			ch <- prometheus.MustNewConstMetric(
-				replicationsSucceed, prometheus.GaugeValue, data[i].Succeed, policyName,
+				replicationTasks, prometheus.GaugeValue, data[i].Succeed, policyName, "succeed",
 			)
 			ch <- prometheus.MustNewConstMetric(
-				replicationsInProgress, prometheus.GaugeValue, data[i].In_progress, policyName,
+				replicationTasks, prometheus.GaugeValue, data[i].In_progress, policyName, "in_progress",
 			)
 			ch <- prometheus.MustNewConstMetric(
-				replicationsStopped, prometheus.GaugeValue, data[i].Stopped, policyName,
+				replicationTasks, prometheus.GaugeValue, data[i].Stopped, policyName, "stopped",
 			)
 		}
 	}

--- a/metrics_replications.go
+++ b/metrics_replications.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func (e *Exporter) collectReplicationsMetric(ch chan<- prometheus.Metric) bool {
+	type policiesMetrics []struct {
+		Id   float64
+		Name string
+		// Extra fields omitted for maintainability: not relevant for current metrics
+	}
+	type policyMetric []struct {
+		Status      string
+		Total       float64
+		Failed      float64
+		Succeed     float64
+		In_progress float64
+		Stopped     float64
+		// Extra fields omitted for maintainability: not relevant for current metrics
+	}
+
+	policiesBody := e.client.request("/api/replication/policies")
+	var policiesData policiesMetrics
+
+	if err := json.Unmarshal(policiesBody, &policiesData); err != nil {
+		level.Error(e.logger).Log("msg", "Error retrieving replication policies", "err", err.Error())
+		return false
+	}
+
+	for i := range policiesData {
+		policyId := strconv.FormatFloat(policiesData[i].Id, 'f', 0, 32)
+		policyName := policiesData[i].Name
+
+		body := e.client.request("/api/replication/executions?policy_id=" + policyId + "&page=1&page_size=1")
+		var data policyMetric
+
+		if err := json.Unmarshal(body, &data); err != nil {
+			level.Error(e.logger).Log("msg", "Error retrieving replication data for policy "+policyId, "err", err.Error())
+			return false
+		}
+
+		for i := range data {
+			var replStatus float64
+			replStatus = 0
+			if data[i].Status == "Succeed" {
+				replStatus = 1
+			}
+			ch <- prometheus.MustNewConstMetric(
+				replicationStatus, prometheus.GaugeValue, replStatus, policyName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				replicationsTotal, prometheus.GaugeValue, data[i].Total, policyName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				replicationsFailed, prometheus.GaugeValue, data[i].Failed, policyName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				replicationsSucceed, prometheus.GaugeValue, data[i].Succeed, policyName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				replicationsInProgress, prometheus.GaugeValue, data[i].In_progress, policyName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				replicationsStopped, prometheus.GaugeValue, data[i].Stopped, policyName,
+			)
+		}
+	}
+	return true
+}

--- a/metrics_replications.go
+++ b/metrics_replications.go
@@ -16,7 +16,6 @@ func (e *Exporter) collectReplicationsMetric(ch chan<- prometheus.Metric) bool {
 	}
 	type policyMetric []struct {
 		Status      string
-		Total       float64
 		Failed      float64
 		Succeed     float64
 		In_progress float64
@@ -52,9 +51,6 @@ func (e *Exporter) collectReplicationsMetric(ch chan<- prometheus.Metric) bool {
 			}
 			ch <- prometheus.MustNewConstMetric(
 				replicationStatus, prometheus.GaugeValue, replStatus, policyName,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				replicationTasks, prometheus.GaugeValue, data[i].Total, policyName, "total",
 			)
 			ch <- prometheus.MustNewConstMetric(
 				replicationTasks, prometheus.GaugeValue, data[i].Failed, policyName, "failed",


### PR DESCRIPTION
This PR adds metrics for replications: for each replication policy, the status and statistics of the last execution is exported as a metric. Useful for scheduled replications.