### PR TITLE
Adding timeout to client request

### DIFF
--- a/harbor_exporter.go
+++ b/harbor_exporter.go
@@ -17,6 +17,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+        "context"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -101,7 +102,9 @@ func (h HarborClient) request(endpoint string) []byte {
 	}
 	req.SetBasicAuth(h.opts.username, h.opts.password)
 
-	resp, err := h.client.Do(req)
+        ctx, cancel := context.WithTimeout(context.Background(), h.opts.timeout * time.Millisecond)
+        defer cancel()
+	resp, err := h.client.Do(req.WithContext(ctx))
 	if err != nil {
 		level.Error(h.logger).Log("msg", "Error handling request for "+endpoint, "err", err.Error())
 		return nil


### PR DESCRIPTION
I find this exporter grabs file handles (specifically sockets) as it runs that it never releases, causing it to eventually stop working.   I'm a go noob, but it looks like you've got a 'timeout' flag that doesn't actually get used when making a request?  I've made this small change which fixes the issue for us.