### PR TITLE
Implement metrics cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,26 @@ _Note: when the harbor.instance flag is used, each metric name starts with `harb
 ./harbor_exporter --help
 ```
 
-* `skip.metrics` - (Optional) value can be `scans|statistics|quotas|repositories|replication`
+---
+
+`skip.metrics` - Skip collection of certain metric groups (optional)
+
+* Value can be `scans|statistics|quotas|repositories|replication`
+
 example:
 ```
 ./harbor_exporter --skip.metrics scans --skip.metrics quotas
+```
+
+---
+
+`cache.enabled` - Enable caching of metrics (optional)
+* Disabled by default.
+* Cache duration can be changed with `--cache.duration` (default 20s).
+
+example:
+```
+./harbor_exporter --cache.enabled --cache.duration 30s
 ```
 
 ### Environment variables


### PR DESCRIPTION
Hi,

thank you for this useful exporter.

With all metric groups enabled, scrapes produce a high load on the Harbor database when many projects, repositories, etc. exist. The high load is amplified in a Prometheus HA setup where multiple Prometheus instances scrape in parallel.

I implemented a simple metrics cache to reduce the load. The exporter behaves the same way as before if no additional flags are set. If caching is enabled with the `cache.enabled` flag, the samples are cached in memory for a configurable duration. Furthermore, `collectMutex` ensures the exporter never collects samples in parallel (for multiple scrape requests) if caching is enabled.

Thanks
Nick