### PR TITLE
Implement metrics cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,26 @@ _Note: when the harbor.instance flag is used, each metric name starts with `harb
 ./harbor_exporter --help
 ```
 
-* `skip.metrics` - (Optional) value can be `scans|statistics|quotas|repositories|replication`
+---
+
+`skip.metrics` - Skip collection of certain metric groups (optional)
+
+* Value can be `scans|statistics|quotas|repositories|replication`
+
 example:
 ```
 ./harbor_exporter --skip.metrics scans --skip.metrics quotas
+```
+
+---
+
+`cache.enabled` - Enable caching of metrics (optional)
+* Disabled by default.
+* Cache duration can be changed with `--cache.duration` (default 20s).
+
+example:
+```
+./harbor_exporter --cache.enabled --cache.duration 30s
 ```
 
 ### Environment variables


### PR DESCRIPTION
Hi,

this MR contains the changes of https://github.com/c4po/harbor_exporter/pull/39 and additionally a fix for issue https://github.com/c4po/harbor_exporter/issues/40

Previously, if the surrounding "Collect" method completed before the anonymous goroutine is finished, the exporter crashed because it tried to write to "outCh" even though "outCh" was already closed by the Prometheus instrumentation library. The fix uses a WaitGroup to ensure the goroutine finishes before the "Collect" method completes.

Thanks
Nick