### PR TITLE
Fetch all results from paginated apis

### DIFF
--- a/metrics_quotas.go
+++ b/metrics_quotas.go
@@ -28,15 +28,20 @@ func (e *HarborExporter) collectQuotasMetric(ch chan<- prometheus.Metric) bool {
 			Storage float64
 		}
 	}
-	body, _ := e.request("/quotas")
 	var data quotaMetric
+	err := e.requestAll("/quotas", func(pageBody []byte) error {
+		var pageData quotaMetric
+		if err := json.Unmarshal(pageBody, &pageData); err != nil {
+			return err
+		}
+		data = append(data, pageData...)
 
-	if err := json.Unmarshal(body, &data); err != nil {
+		return nil
+	})
+	if err != nil {
 		level.Error(e.logger).Log(err.Error())
 		return false
 	}
-
-	level.Debug(e.logger).Log("body", body)
 
 	for i := range data {
 		if data[i].Ref.Name == "" || data[i].Ref.Id == 0 {


### PR DESCRIPTION
When fetching a list of results from harbor, check the x-total-count
header to determine if more pages of results need to be fetched

Fix #29

Page size is configurable. I've seen harbor's nginx return a gateway timeout when attempting to use harbor's maximum page size (500) so the default is 50.