### PR TITLE
Report the latency of gathered metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,26 @@ make dockerbuild
 |harbor_up| | |
 |harbor_health| | |
 |harbor_components_health| | component=[chartmuseum,core,database,jobservice,notary,portal,redis,registry,registryctl]|
+|harbor_health_latency| | |
 |harbor_scans_completed | | |
 |harbor_scans_total | | |
 |harbor_scans_requester | | |
+|harbor_scans_latency| | |
 |harbor_project_count_total| |type=[private_project, public_project, total_project]|
 |harbor_repo_count_total| |type=[private_repo, public_repo, total_repo]|
+|harbor_statistics_latency| | |
 |harbor_quotas_count_total| |repo_id, repo_name, type=[hard, used]|
 |harbor_quotas_size_bytes| | repo_id, repo_name, type=[hard, used]|
+|harbor_quotas_latency| | |
 |harbor_system_volumes_bytes| |storage=[free, total]|
+|harbor_system_volumes_latency| | |
 |harbor_repositories_pull_total| |repo_id, repo_name|
 |harbor_repositories_star_total| |repo_id, repo_name|
 |harbor_repositories_tags_total| |repo_id, repo_name|
+|harbor_repositories_latency| | |
 |harbor_replication_status|status of the last execution of this replication policy: Succeed = 1, any other status = 0|repl_pol_name|
 |harbor_replication_tasks|number of replication tasks, with various results, in the latest execution of this replication policy|repl_pol_name, result=[failed, succeed, in_progress, stopped]|
+|harbor_replication_latency| | |
 
 _Note: when the harbor.instance flag is used, each metric name starts with `harbor_instancename_` instead of just `harbor_`._
 

--- a/harbor_exporter.go
+++ b/harbor_exporter.go
@@ -100,19 +100,26 @@ func createMetrics(instanceName string) {
 	allMetrics["up"] = newMetricInfo(instanceName, "up", "Was the last query of harbor successful.", prometheus.GaugeValue, nil, nil)
 	allMetrics["health"] = newMetricInfo(instanceName, "health", "Harbor overall health status: Healthy = 1, Unhealthy = 0", prometheus.GaugeValue, nil, nil)
 	allMetrics["components_health"] = newMetricInfo(instanceName, "components_health", "Harbor components health status: Healthy = 1, Unhealthy = 0", prometheus.GaugeValue, componentLabelNames, nil)
+	allMetrics["health_latency"] = newMetricInfo(instanceName, "health_latency", "Time in seconds to collect health metrics", prometheus.GaugeValue, nil, nil)
 	allMetrics["scans_total"] = newMetricInfo(instanceName, "scans_total", "metrics of the latest scan all process", prometheus.GaugeValue, nil, nil)
 	allMetrics["scans_completed"] = newMetricInfo(instanceName, "scans_completed", "metrics of the latest scan all process", prometheus.GaugeValue, nil, nil)
 	allMetrics["scans_requester"] = newMetricInfo(instanceName, "scans_requester", "metrics of the latest scan all process", prometheus.GaugeValue, nil, nil)
+	allMetrics["scans_latency"] = newMetricInfo(instanceName, "scans_latency", "Time in seconds to collect scan metrics", prometheus.GaugeValue, nil, nil)
 	allMetrics["project_count_total"] = newMetricInfo(instanceName, "project_count_total", "projects number relevant to the user", prometheus.GaugeValue, typeLabelNames, nil)
 	allMetrics["repo_count_total"] = newMetricInfo(instanceName, "repo_count_total", "repositories number relevant to the user", prometheus.GaugeValue, typeLabelNames, nil)
+	allMetrics["statistics_latency"] = newMetricInfo(instanceName, "statistics_latency", "Time in seconds to collect statistics metrics", prometheus.GaugeValue, nil, nil)
 	allMetrics["quotas_count_total"] = newMetricInfo(instanceName, "quotas_count_total", "quotas", prometheus.GaugeValue, quotaLabelNames, nil)
 	allMetrics["quotas_size_bytes"] = newMetricInfo(instanceName, "quotas_size_bytes", "quotas", prometheus.GaugeValue, quotaLabelNames, nil)
+	allMetrics["quotas_latency"] = newMetricInfo(instanceName, "quotas_latency", "Time in seconds to collect quota metrics", prometheus.GaugeValue, nil, nil)
 	allMetrics["system_volumes_bytes"] = newMetricInfo(instanceName, "system_volumes_bytes", "Get system volume info (total/free size).", prometheus.GaugeValue, storageLabelNames, nil)
+	allMetrics["system_volumes_latency"] = newMetricInfo(instanceName, "system_volumes_latency", "Time in seconds to collect system_volume metrics", prometheus.GaugeValue, nil, nil)
 	allMetrics["repositories_pull_total"] = newMetricInfo(instanceName, "repositories_pull_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
 	allMetrics["repositories_star_total"] = newMetricInfo(instanceName, "repositories_star_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
 	allMetrics["repositories_tags_total"] = newMetricInfo(instanceName, "repositories_tags_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
+	allMetrics["repositories_latency"] = newMetricInfo(instanceName, "repositories_latency", "Time in seconds to collect repository metrics", prometheus.GaugeValue, nil, nil)
 	allMetrics["replication_status"] = newMetricInfo(instanceName, "replication_status", "Get status of the last execution of this replication policy: Succeed = 1, any other status = 0.", prometheus.GaugeValue, replicationLabelNames, nil)
 	allMetrics["replication_tasks"] = newMetricInfo(instanceName, "replication_tasks", "Get number of replication tasks, with various results, in the latest execution of this replication policy.", prometheus.GaugeValue, replicationTaskLabelNames, nil)
+	allMetrics["replication_latency"] = newMetricInfo(instanceName, "replication_latency", "Time in seconds to collect replication metrics", prometheus.GaugeValue, nil, nil)
 }
 
 type promHTTPLogger struct {
@@ -283,6 +290,14 @@ func checkHarborVersion(h *HarborExporter) error {
 		return errors.New("unable to determine harbor version")
 	}
 	return nil
+}
+
+func reportLatency(start time.Time, metric string, ch chan<- prometheus.Metric) {
+	end := time.Now()
+	latency := end.Sub(start).Seconds()
+	ch <- prometheus.MustNewConstMetric(
+		allMetrics[metric].Desc, allMetrics[metric].Type, latency,
+	)
 }
 
 // Describe describes all the metrics ever exported by the Harbor exporter. It

--- a/metrics_health.go
+++ b/metrics_health.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func (e *HarborExporter) collectHealthMetric(ch chan<- prometheus.Metric) bool {
-
+	start := time.Now()
 	type scanMetric struct {
 		Status     string `json:"status"`
 		Components []struct {
@@ -34,5 +35,6 @@ func (e *HarborExporter) collectHealthMetric(ch chan<- prometheus.Metric) bool {
 		)
 	}
 
+	reportLatency(start, "health_latency", ch)
 	return true
 }

--- a/metrics_quotas.go
+++ b/metrics_quotas.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (e *HarborExporter) collectQuotasMetric(ch chan<- prometheus.Metric) bool {
+	start := time.Now()
 
 	type quotaMetric []struct {
 		Id  float64
@@ -62,5 +63,7 @@ func (e *HarborExporter) collectQuotasMetric(ch chan<- prometheus.Metric) bool {
 			)
 		}
 	}
+
+	reportLatency(start, "quotas_latency", ch)
 	return true
 }

--- a/metrics_replications.go
+++ b/metrics_replications.go
@@ -3,12 +3,14 @@ package main
 import (
 	"encoding/json"
 	"strconv"
+	"time"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func (e *HarborExporter) collectReplicationsMetric(ch chan<- prometheus.Metric) bool {
+	start := time.Now()
 	type policiesMetrics []struct {
 		Id   float64
 		Name string
@@ -73,5 +75,7 @@ func (e *HarborExporter) collectReplicationsMetric(ch chan<- prometheus.Metric) 
 			)
 		}
 	}
+
+	reportLatency(start, "replication_latency", ch)
 	return true
 }

--- a/metrics_repositories.go
+++ b/metrics_repositories.go
@@ -10,6 +10,7 @@ import (
 )
 
 func (e *HarborExporter) collectRepositoriesMetric(ch chan<- prometheus.Metric) bool {
+	start := time.Now()
 	type projectsMetrics []struct {
 		Project_id  float64
 		Owner_id    float64
@@ -127,5 +128,7 @@ func (e *HarborExporter) collectRepositoriesMetric(ch chan<- prometheus.Metric) 
 			}
 		}
 	}
+
+	reportLatency(start, "repositories_latency", ch)
 	return true
 }

--- a/metrics_scan.go
+++ b/metrics_scan.go
@@ -5,9 +5,11 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"strconv"
+	"time"
 )
 
 func (e *HarborExporter) collectScanMetric(ch chan<- prometheus.Metric) bool {
+	start := time.Now()
 
 	type scanMetric struct {
 		Total     float64
@@ -36,5 +38,7 @@ func (e *HarborExporter) collectScanMetric(ch chan<- prometheus.Metric) bool {
 	ch <- prometheus.MustNewConstMetric(
 		allMetrics["scans_completed"].Desc, allMetrics["scans_completed"].Type, float64(data.Completed),
 	)
+
+	reportLatency(start, "scans_latency", ch)
 	return true
 }

--- a/metrics_statistics.go
+++ b/metrics_statistics.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"time"
 )
 
 func (e *HarborExporter) collectStatisticsMetric(ch chan<- prometheus.Metric) bool {
+	start := time.Now()
 
 	type statisticsMetric struct {
 		Total_project_count   float64
@@ -50,5 +52,6 @@ func (e *HarborExporter) collectStatisticsMetric(ch chan<- prometheus.Metric) bo
 		allMetrics["repo_count_total"].Desc, allMetrics["repo_count_total"].Type, data.Private_repo_count, "private_repo",
 	)
 
+	reportLatency(start, "statistics_latency", ch)
 	return true
 }

--- a/metrics_systemvolumes.go
+++ b/metrics_systemvolumes.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"time"
 )
 
 func (e *HarborExporter) collectSystemVolumesMetric(ch chan<- prometheus.Metric) bool {
+	start := time.Now()
 	type systemVolumesMetric struct {
 		Storage struct {
 			Total float64
@@ -27,5 +29,6 @@ func (e *HarborExporter) collectSystemVolumesMetric(ch chan<- prometheus.Metric)
 		allMetrics["system_volumes_bytes"].Desc, allMetrics["system_volumes_bytes"].Type, data.Storage.Free, "free",
 	)
 
+	reportLatency(start, "system_volumes_latency", ch)
 	return true
 }


### PR DESCRIPTION
This can be used as a performance measure of both of harbor and the
exporter itself, and can be used to measure improvements.