### PR TITLE
Fetch harbor endpoints in parallel

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sync"
+	"time"
+)
+
+type Cache struct {
+	cacheEnabled    bool
+	cacheDuration   time.Duration
+	lastCollectTime time.Time
+	cache           []prometheus.Metric
+	collectMutex    sync.Mutex
+}
+
+func NewCache(cacheEnabled bool, cacheDuration time.Duration) *Cache {
+	return &Cache{
+		cacheEnabled:    cacheEnabled,
+		cacheDuration:   cacheDuration,
+		cache:           make([]prometheus.Metric, 0),
+		lastCollectTime: time.Unix(0, 0),
+		collectMutex:    sync.Mutex{},
+	}
+}
+
+func (c *Cache) ReplayMetrics(outCh chan<- prometheus.Metric) bool {
+	if c.cacheEnabled {
+		c.collectMutex.Lock()
+		defer c.collectMutex.Unlock()
+		expiry := c.lastCollectTime.Add(c.cacheDuration)
+		if time.Now().Before(expiry) {
+			// Return cached
+			for _, cachedMetric := range c.cache {
+				outCh <- cachedMetric
+			}
+			return true
+		}
+		// Reset cache for fresh sampling, but re-use underlying array
+		c.cache = c.cache[:0]
+	}
+	return false
+}
+
+func (c *Cache) StoreAndForwaredMetrics(outCh chan<- prometheus.Metric) (chan prometheus.Metric, *sync.WaitGroup) {
+	samplesCh := make(chan prometheus.Metric)
+	// Use WaitGroup to ensure outCh isn't closed before the goroutine is finished
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		if c.cacheEnabled {
+			c.collectMutex.Lock()
+			defer c.collectMutex.Unlock()
+			// Prometheus will reject duplicate metrics
+			c.cache = c.cache[:0]
+		}
+		for metric := range samplesCh {
+			outCh <- metric
+			if c.cacheEnabled {
+				c.cache = append(c.cache, metric)
+			}
+		}
+		wg.Done()
+		c.lastCollectTime = time.Now()
+	}()
+	return samplesCh, &wg
+}

--- a/harbor_exporter.go
+++ b/harbor_exporter.go
@@ -98,27 +98,12 @@ func createMetrics(instanceName string) {
 	allMetrics = make(map[string]metricInfo)
 
 	allMetrics["up"] = newMetricInfo(instanceName, "up", "Was the last query of harbor successful.", prometheus.GaugeValue, nil, nil)
-	allMetrics["health"] = newMetricInfo(instanceName, "health", "Harbor overall health status: Healthy = 1, Unhealthy = 0", prometheus.GaugeValue, nil, nil)
-	allMetrics["components_health"] = newMetricInfo(instanceName, "components_health", "Harbor components health status: Healthy = 1, Unhealthy = 0", prometheus.GaugeValue, componentLabelNames, nil)
 	allMetrics["health_latency"] = newMetricInfo(instanceName, "health_latency", "Time in seconds to collect health metrics", prometheus.GaugeValue, nil, nil)
-	allMetrics["scans_total"] = newMetricInfo(instanceName, "scans_total", "metrics of the latest scan all process", prometheus.GaugeValue, nil, nil)
-	allMetrics["scans_completed"] = newMetricInfo(instanceName, "scans_completed", "metrics of the latest scan all process", prometheus.GaugeValue, nil, nil)
-	allMetrics["scans_requester"] = newMetricInfo(instanceName, "scans_requester", "metrics of the latest scan all process", prometheus.GaugeValue, nil, nil)
 	allMetrics["scans_latency"] = newMetricInfo(instanceName, "scans_latency", "Time in seconds to collect scan metrics", prometheus.GaugeValue, nil, nil)
-	allMetrics["project_count_total"] = newMetricInfo(instanceName, "project_count_total", "projects number relevant to the user", prometheus.GaugeValue, typeLabelNames, nil)
-	allMetrics["repo_count_total"] = newMetricInfo(instanceName, "repo_count_total", "repositories number relevant to the user", prometheus.GaugeValue, typeLabelNames, nil)
 	allMetrics["statistics_latency"] = newMetricInfo(instanceName, "statistics_latency", "Time in seconds to collect statistics metrics", prometheus.GaugeValue, nil, nil)
-	allMetrics["quotas_count_total"] = newMetricInfo(instanceName, "quotas_count_total", "quotas", prometheus.GaugeValue, quotaLabelNames, nil)
-	allMetrics["quotas_size_bytes"] = newMetricInfo(instanceName, "quotas_size_bytes", "quotas", prometheus.GaugeValue, quotaLabelNames, nil)
 	allMetrics["quotas_latency"] = newMetricInfo(instanceName, "quotas_latency", "Time in seconds to collect quota metrics", prometheus.GaugeValue, nil, nil)
-	allMetrics["system_volumes_bytes"] = newMetricInfo(instanceName, "system_volumes_bytes", "Get system volume info (total/free size).", prometheus.GaugeValue, storageLabelNames, nil)
 	allMetrics["system_volumes_latency"] = newMetricInfo(instanceName, "system_volumes_latency", "Time in seconds to collect system_volume metrics", prometheus.GaugeValue, nil, nil)
-	allMetrics["repositories_pull_total"] = newMetricInfo(instanceName, "repositories_pull_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
-	allMetrics["repositories_star_total"] = newMetricInfo(instanceName, "repositories_star_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
-	allMetrics["repositories_tags_total"] = newMetricInfo(instanceName, "repositories_tags_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
 	allMetrics["repositories_latency"] = newMetricInfo(instanceName, "repositories_latency", "Time in seconds to collect repository metrics", prometheus.GaugeValue, nil, nil)
-	allMetrics["replication_status"] = newMetricInfo(instanceName, "replication_status", "Get status of the last execution of this replication policy: Succeed = 1, any other status = 0.", prometheus.GaugeValue, replicationLabelNames, nil)
-	allMetrics["replication_tasks"] = newMetricInfo(instanceName, "replication_tasks", "Get number of replication tasks, with various results, in the latest execution of this replication policy.", prometheus.GaugeValue, replicationTaskLabelNames, nil)
 	allMetrics["replication_latency"] = newMetricInfo(instanceName, "replication_latency", "Time in seconds to collect replication metrics", prometheus.GaugeValue, nil, nil)
 }
 
@@ -341,27 +326,7 @@ func (e *HarborExporter) Collect(outCh chan<- prometheus.Metric) {
 	}()
 
 	ok := true
-	if collectMetricsGroup[metricsGroupHealth] {
-		ok = e.collectHealthMetric(samplesCh) && ok
-	}
-	if collectMetricsGroup[metricsGroupScans] {
-		ok = e.collectScanMetric(samplesCh) && ok
-	}
-	if collectMetricsGroup[metricsGroupStatistics] {
-		ok = e.collectStatisticsMetric(samplesCh) && ok
-	}
-	if collectMetricsGroup[metricsGroupStatistics] {
-		ok = e.collectSystemVolumesMetric(samplesCh) && ok
-	}
-	if collectMetricsGroup[metricsGroupQuotas] {
-		ok = e.collectQuotasMetric(samplesCh) && ok
-	}
-	if collectMetricsGroup[metricsGroupRepositories] {
-		ok = e.collectRepositoriesMetric(samplesCh) && ok
-	}
-	if collectMetricsGroup[metricsGroupReplication] {
-		ok = e.collectReplicationsMetric(samplesCh) && ok
-	}
+	// TODO fix up metric
 
 	if ok {
 		samplesCh <- prometheus.MustNewConstMetric(
@@ -439,6 +404,27 @@ func main() {
 	}
 
 	createMetrics(harborInstance.instance)
+	if collectMetricsGroup[metricsGroupHealth] {
+		prometheus.MustRegister(CreateHealthCollector(harborInstance))
+	}
+	if collectMetricsGroup[metricsGroupQuotas] {
+		prometheus.MustRegister(CreateQuotaCollector(harborInstance))
+	}
+	if collectMetricsGroup[metricsGroupReplication] {
+		prometheus.MustRegister(CreateReplicationCollector(harborInstance))
+	}
+	if collectMetricsGroup[metricsGroupRepositories] {
+		prometheus.MustRegister(CreateRepositoryCollector(harborInstance))
+	}
+	if collectMetricsGroup[metricsGroupScans] {
+		prometheus.MustRegister(CreateScanCollector(harborInstance))
+	}
+	if collectMetricsGroup[metricsGroupStatistics] {
+		prometheus.MustRegister(CreateStatsCollector(harborInstance))
+	}
+	if collectMetricsGroup[metricsGroupStatistics] {
+		prometheus.MustRegister(CreateVolumeCollector(harborInstance))
+	}
 
 	prometheus.MustRegister(harborInstance)
 	prometheus.MustRegister(version.NewCollector("harbor_exporter"))

--- a/metrics_health.go
+++ b/metrics_health.go
@@ -8,7 +8,28 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func (e *HarborExporter) collectHealthMetric(ch chan<- prometheus.Metric) bool {
+type HealthCollector struct {
+	exporter *HarborExporter
+	metrics  map[string]metricInfo
+}
+
+func CreateHealthCollector(e *HarborExporter) *HealthCollector {
+	hc := HealthCollector{
+		exporter: e,
+		metrics:  make(map[string]metricInfo),
+	}
+	hc.metrics["health"] = newMetricInfo(e.instance, "health", "Harbor overall health status: Healthy = 1, Unhealthy = 0", prometheus.GaugeValue, nil, nil)
+	hc.metrics["components_health"] = newMetricInfo(e.instance, "components_health", "Harbor components health status: Healthy = 1, Unhealthy = 0", prometheus.GaugeValue, componentLabelNames, nil)
+	return &hc
+}
+
+func (hc *HealthCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, m := range hc.metrics {
+		ch <- m.Desc
+	}
+}
+
+func (hc *HealthCollector) Collect(ch chan<- prometheus.Metric) {
 	start := time.Now()
 	type scanMetric struct {
 		Status     string `json:"status"`
@@ -17,24 +38,22 @@ func (e *HarborExporter) collectHealthMetric(ch chan<- prometheus.Metric) bool {
 			Status string `json:"status"`
 		}
 	}
-	body, _ := e.request("/health")
+	body, _ := hc.exporter.request("/health")
 	var data scanMetric
 
 	if err := json.Unmarshal(body, &data); err != nil {
-		level.Error(e.logger).Log(err.Error())
-		return false
+		level.Error(hc.exporter.logger).Log(err.Error())
+		return
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		allMetrics["health"].Desc, allMetrics["health"].Type, float64(Status2i(data.Status)),
+		hc.metrics["health"].Desc, hc.metrics["health"].Type, float64(Status2i(data.Status)),
 	)
 
 	for _, c := range data.Components {
 		ch <- prometheus.MustNewConstMetric(
-			allMetrics["components_health"].Desc, allMetrics["components_health"].Type, float64(Status2i(c.Status)), c.Name,
+			hc.metrics["components_health"].Desc, hc.metrics["components_health"].Type, float64(Status2i(c.Status)), c.Name,
 		)
 	}
-
 	reportLatency(start, "health_latency", ch)
-	return true
 }

--- a/metrics_health.go
+++ b/metrics_health.go
@@ -43,6 +43,7 @@ func (hc *HealthCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := json.Unmarshal(body, &data); err != nil {
 		level.Error(hc.exporter.logger).Log(err.Error())
+		hc.exporter.healthChan <- false
 		return
 	}
 
@@ -56,4 +57,5 @@ func (hc *HealthCollector) Collect(ch chan<- prometheus.Metric) {
 		)
 	}
 	reportLatency(start, "health_latency", ch)
+	hc.exporter.healthChan <- true
 }

--- a/metrics_quotas.go
+++ b/metrics_quotas.go
@@ -63,6 +63,7 @@ func (qc *QuotaCollector) Collect(ch chan<- prometheus.Metric) {
 	})
 	if err != nil {
 		level.Error(qc.exporter.logger).Log(err.Error())
+		qc.exporter.quotaChan <- false
 		return
 	}
 
@@ -86,4 +87,5 @@ func (qc *QuotaCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 	}
 	reportLatency(start, "quotas_latency", ch)
+	qc.exporter.quotaChan <- true
 }

--- a/metrics_quotas.go
+++ b/metrics_quotas.go
@@ -8,7 +8,28 @@ import (
 	"time"
 )
 
-func (e *HarborExporter) collectQuotasMetric(ch chan<- prometheus.Metric) bool {
+type QuotaCollector struct {
+	exporter *HarborExporter
+	metrics  map[string]metricInfo
+}
+
+func CreateQuotaCollector(e *HarborExporter) *QuotaCollector {
+	qc := QuotaCollector{
+		exporter: e,
+		metrics:  make(map[string]metricInfo),
+	}
+	qc.metrics["quotas_count_total"] = newMetricInfo(e.instance, "quotas_count_total", "quotas", prometheus.GaugeValue, quotaLabelNames, nil)
+	qc.metrics["quotas_size_bytes"] = newMetricInfo(e.instance, "quotas_size_bytes", "quotas", prometheus.GaugeValue, quotaLabelNames, nil)
+	return &qc
+}
+
+func (qc *QuotaCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, m := range qc.metrics {
+		ch <- m.Desc
+	}
+}
+
+func (qc *QuotaCollector) Collect(ch chan<- prometheus.Metric) {
 	start := time.Now()
 
 	type quotaMetric []struct {
@@ -29,8 +50,9 @@ func (e *HarborExporter) collectQuotasMetric(ch chan<- prometheus.Metric) bool {
 			Storage float64
 		}
 	}
+
 	var data quotaMetric
-	err := e.requestAll("/quotas", func(pageBody []byte) error {
+	err := qc.exporter.requestAll("/quotas", func(pageBody []byte) error {
 		var pageData quotaMetric
 		if err := json.Unmarshal(pageBody, &pageData); err != nil {
 			return err
@@ -40,30 +62,28 @@ func (e *HarborExporter) collectQuotasMetric(ch chan<- prometheus.Metric) bool {
 		return nil
 	})
 	if err != nil {
-		level.Error(e.logger).Log(err.Error())
-		return false
+		level.Error(qc.exporter.logger).Log(err.Error())
+		return
 	}
 
 	for i := range data {
 		if data[i].Ref.Name == "" || data[i].Ref.Id == 0 {
-			level.Debug(e.logger).Log(data[i].Ref.Id, data[i].Ref.Name)
+			level.Debug(qc.exporter.logger).Log(data[i].Ref.Id, data[i].Ref.Name)
 		} else {
 			repoid := strconv.FormatFloat(data[i].Ref.Id, 'f', 0, 32)
 			ch <- prometheus.MustNewConstMetric(
-				allMetrics["quotas_count_total"].Desc, allMetrics["quotas_count_total"].Type, data[i].Hard.Count, "hard", data[i].Ref.Name, repoid,
+				qc.metrics["quotas_count_total"].Desc, qc.metrics["quotas_count_total"].Type, data[i].Hard.Count, "hard", data[i].Ref.Name, repoid,
 			)
 			ch <- prometheus.MustNewConstMetric(
-				allMetrics["quotas_count_total"].Desc, allMetrics["quotas_count_total"].Type, data[i].Used.Count, "used", data[i].Ref.Name, repoid,
+				qc.metrics["quotas_count_total"].Desc, qc.metrics["quotas_count_total"].Type, data[i].Used.Count, "used", data[i].Ref.Name, repoid,
 			)
 			ch <- prometheus.MustNewConstMetric(
-				allMetrics["quotas_size_bytes"].Desc, allMetrics["quotas_size_bytes"].Type, data[i].Hard.Storage, "hard", data[i].Ref.Name, repoid,
+				qc.metrics["quotas_size_bytes"].Desc, qc.metrics["quotas_size_bytes"].Type, data[i].Hard.Storage, "hard", data[i].Ref.Name, repoid,
 			)
 			ch <- prometheus.MustNewConstMetric(
-				allMetrics["quotas_size_bytes"].Desc, allMetrics["quotas_size_bytes"].Type, data[i].Used.Storage, "used", data[i].Ref.Name, repoid,
+				qc.metrics["quotas_size_bytes"].Desc, qc.metrics["quotas_size_bytes"].Type, data[i].Used.Storage, "used", data[i].Ref.Name, repoid,
 			)
 		}
 	}
-
 	reportLatency(start, "quotas_latency", ch)
-	return true
 }

--- a/metrics_replications.go
+++ b/metrics_replications.go
@@ -58,6 +58,7 @@ func (rc *ReplicationCollector) Collect(ch chan<- prometheus.Metric) {
 	})
 	if err != nil {
 		level.Error(rc.exporter.logger).Log("msg", "Error retrieving replication policies", "err", err.Error())
+		rc.exporter.replicationChan <- false
 		return
 	}
 
@@ -70,6 +71,7 @@ func (rc *ReplicationCollector) Collect(ch chan<- prometheus.Metric) {
 
 		if err := json.Unmarshal(body, &data); err != nil {
 			level.Error(rc.exporter.logger).Log("msg", "Error retrieving replication data for policy "+policyId, "err", err.Error())
+			rc.exporter.replicationChan <- false
 			return
 		}
 
@@ -96,6 +98,6 @@ func (rc *ReplicationCollector) Collect(ch chan<- prometheus.Metric) {
 			)
 		}
 	}
-
 	reportLatency(start, "replication_latency", ch)
+	rc.exporter.replicationChan <- true
 }

--- a/metrics_repositories.go
+++ b/metrics_repositories.go
@@ -9,7 +9,29 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func (e *HarborExporter) collectRepositoriesMetric(ch chan<- prometheus.Metric) bool {
+type RepositoryCollector struct {
+	exporter *HarborExporter
+	metrics  map[string]metricInfo
+}
+
+func CreateRepositoryCollector(e *HarborExporter) *RepositoryCollector {
+	rc := RepositoryCollector{
+		exporter: e,
+		metrics:  make(map[string]metricInfo),
+	}
+	rc.metrics["repositories_pull_total"] = newMetricInfo(e.instance, "repositories_pull_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
+	rc.metrics["repositories_star_total"] = newMetricInfo(e.instance, "repositories_star_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
+	rc.metrics["repositories_tags_total"] = newMetricInfo(e.instance, "repositories_tags_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
+	return &rc
+}
+
+func (rc *RepositoryCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, m := range rc.metrics {
+		ch <- m.Desc
+	}
+}
+
+func (rc *RepositoryCollector) Collect(ch chan<- prometheus.Metric) {
 	start := time.Now()
 	type projectsMetrics []struct {
 		Project_id  float64
@@ -50,8 +72,9 @@ func (e *HarborExporter) collectRepositoriesMetric(ch chan<- prometheus.Metric) 
 		Creation_time  time.Time
 		Update_time    time.Time
 	}
+
 	var projectsData projectsMetrics
-	err := e.requestAll("/projects", func(pageBody []byte) error {
+	err := rc.exporter.requestAll("/projects", func(pageBody []byte) error {
 		var pageData projectsMetrics
 		if err := json.Unmarshal(pageBody, &pageData); err != nil {
 			return err
@@ -61,15 +84,15 @@ func (e *HarborExporter) collectRepositoriesMetric(ch chan<- prometheus.Metric) 
 		return nil
 	})
 	if err != nil {
-		level.Error(e.logger).Log(err.Error())
-		return false
+		level.Error(rc.exporter.logger).Log(err.Error())
+		return
 	}
 
 	for i := range projectsData {
 		projectId := strconv.FormatFloat(projectsData[i].Project_id, 'f', 0, 32)
-		if e.isV2 {
+		if rc.exporter.isV2 {
 			var data repositoriesMetricV2
-			err := e.requestAll("/projects/"+projectsData[i].Name+"/repositories", func(pageBody []byte) error {
+			err := rc.exporter.requestAll("/projects/"+projectsData[i].Name+"/repositories", func(pageBody []byte) error {
 				var pageData repositoriesMetricV2
 				if err := json.Unmarshal(pageBody, &pageData); err != nil {
 					return err
@@ -80,26 +103,26 @@ func (e *HarborExporter) collectRepositoriesMetric(ch chan<- prometheus.Metric) 
 				return nil
 			})
 			if err != nil {
-				level.Error(e.logger).Log(err.Error())
-				return false
+				level.Error(rc.exporter.logger).Log(err)
+				return
 			}
 
 			for i := range data {
 				repoId := strconv.FormatFloat(data[i].Id, 'f', 0, 32)
 				ch <- prometheus.MustNewConstMetric(
-					allMetrics["repositories_pull_total"].Desc, allMetrics["repositories_pull_total"].Type, data[i].Pull_count, data[i].Name, repoId,
+					rc.metrics["repositories_pull_total"].Desc, rc.metrics["repositories_pull_total"].Type, data[i].Pull_count, data[i].Name, repoId,
 				)
 				// ch <- prometheus.MustNewConstMetric(
-				// 	allMetrics["repositories_star_total"].Desc, allMetrics["repositories_star_total"].Type, data[i].Star_count, data[i].Name, repoId,
+				// 	rc.metrics["repositories_star_total"].Desc, rc.metrics["repositories_star_total"].Type, data[i].Star_count, data[i].Name, repoId,
 				// )
 				ch <- prometheus.MustNewConstMetric(
-					allMetrics["repositories_tags_total"].Desc, allMetrics["repositories_tags_total"].Type, data[i].Artifact_count, data[i].Name, repoId,
+					rc.metrics["repositories_tags_total"].Desc, rc.metrics["repositories_tags_total"].Type, data[i].Artifact_count, data[i].Name, repoId,
 				)
 			}
 
 		} else {
 			var data repositoriesMetric
-			err := e.requestAll("/repositories?project_id="+projectId, func(pageBody []byte) error {
+			err := rc.exporter.requestAll("/repositories?project_id="+projectId, func(pageBody []byte) error {
 				var pageData repositoriesMetric
 				if err := json.Unmarshal(pageBody, &pageData); err != nil {
 					return err
@@ -110,25 +133,24 @@ func (e *HarborExporter) collectRepositoriesMetric(ch chan<- prometheus.Metric) 
 				return nil
 			})
 			if err != nil {
-				level.Error(e.logger).Log(err.Error())
-				return false
+				level.Error(rc.exporter.logger).Log(err.Error())
+				return
 			}
 
 			for i := range data {
 				repoId := strconv.FormatFloat(data[i].Id, 'f', 0, 32)
 				ch <- prometheus.MustNewConstMetric(
-					allMetrics["repositories_pull_total"].Desc, allMetrics["repositories_pull_total"].Type, data[i].Pull_count, data[i].Name, repoId,
+					rc.metrics["repositories_pull_total"].Desc, rc.metrics["repositories_pull_total"].Type, data[i].Pull_count, data[i].Name, repoId,
 				)
 				ch <- prometheus.MustNewConstMetric(
-					allMetrics["repositories_star_total"].Desc, allMetrics["repositories_star_total"].Type, data[i].Star_count, data[i].Name, repoId,
+					rc.metrics["repositories_star_total"].Desc, rc.metrics["repositories_star_total"].Type, data[i].Star_count, data[i].Name, repoId,
 				)
 				ch <- prometheus.MustNewConstMetric(
-					allMetrics["repositories_tags_total"].Desc, allMetrics["repositories_tags_total"].Type, data[i].Tags_count, data[i].Name, repoId,
+					rc.metrics["repositories_tags_total"].Desc, rc.metrics["repositories_tags_total"].Type, data[i].Tags_count, data[i].Name, repoId,
 				)
 			}
 		}
 	}
 
 	reportLatency(start, "repositories_latency", ch)
-	return true
 }

--- a/metrics_repositories.go
+++ b/metrics_repositories.go
@@ -85,6 +85,7 @@ func (rc *RepositoryCollector) Collect(ch chan<- prometheus.Metric) {
 	})
 	if err != nil {
 		level.Error(rc.exporter.logger).Log(err.Error())
+		rc.exporter.repositoryChan <- false
 		return
 	}
 
@@ -134,6 +135,7 @@ func (rc *RepositoryCollector) Collect(ch chan<- prometheus.Metric) {
 			})
 			if err != nil {
 				level.Error(rc.exporter.logger).Log(err.Error())
+				rc.exporter.repositoryChan <- false
 				return
 			}
 
@@ -151,6 +153,6 @@ func (rc *RepositoryCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 		}
 	}
-
 	reportLatency(start, "repositories_latency", ch)
+	rc.exporter.repositoryChan <- true
 }

--- a/metrics_scan.go
+++ b/metrics_scan.go
@@ -45,6 +45,7 @@ func (sc *ScanCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := json.Unmarshal(body, &data); err != nil {
 		level.Error(sc.exporter.logger).Log(err.Error())
+		sc.exporter.scanChan <- false
 		return
 	}
 
@@ -60,6 +61,6 @@ func (sc *ScanCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		sc.metrics["scans_completed"].Desc, sc.metrics["scans_completed"].Type, float64(data.Completed),
 	)
-
 	reportLatency(start, "scans_latency", ch)
+	sc.exporter.scanChan <- true
 }

--- a/metrics_scan.go
+++ b/metrics_scan.go
@@ -8,7 +8,29 @@ import (
 	"time"
 )
 
-func (e *HarborExporter) collectScanMetric(ch chan<- prometheus.Metric) bool {
+type ScanCollector struct {
+	exporter *HarborExporter
+	metrics  map[string]metricInfo
+}
+
+func CreateScanCollector(e *HarborExporter) *ScanCollector {
+	sc := ScanCollector{
+		exporter: e,
+		metrics:  make(map[string]metricInfo),
+	}
+	sc.metrics["scans_total"] = newMetricInfo(e.instance, "scans_total", "metrics of the latest scan all process", prometheus.GaugeValue, nil, nil)
+	sc.metrics["scans_completed"] = newMetricInfo(e.instance, "scans_completed", "metrics of the latest scan all process", prometheus.GaugeValue, nil, nil)
+	sc.metrics["scans_requester"] = newMetricInfo(e.instance, "scans_requester", "metrics of the latest scan all process", prometheus.GaugeValue, nil, nil)
+	return &sc
+}
+
+func (sc *ScanCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, m := range sc.metrics {
+		ch <- m.Desc
+	}
+}
+
+func (sc *ScanCollector) Collect(ch chan<- prometheus.Metric) {
 	start := time.Now()
 
 	type scanMetric struct {
@@ -18,27 +40,26 @@ func (e *HarborExporter) collectScanMetric(ch chan<- prometheus.Metric) bool {
 		Requester string
 		Ongoing   bool
 	}
-	body, _ := e.request("/scans/all/metrics")
+	body, _ := sc.exporter.request("/scans/all/metrics")
 	var data scanMetric
 
 	if err := json.Unmarshal(body, &data); err != nil {
-		level.Error(e.logger).Log(err.Error())
-		return false
+		level.Error(sc.exporter.logger).Log(err.Error())
+		return
 	}
 
 	scan_requester, _ := strconv.ParseFloat(data.Requester, 64)
 	ch <- prometheus.MustNewConstMetric(
-		allMetrics["scans_requester"].Desc, allMetrics["scans_requester"].Type, float64(scan_requester),
+		sc.metrics["scans_requester"].Desc, sc.metrics["scans_requester"].Type, float64(scan_requester),
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		allMetrics["scans_total"].Desc, allMetrics["scans_total"].Type, float64(data.Total),
+		sc.metrics["scans_total"].Desc, sc.metrics["scans_total"].Type, float64(data.Total),
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		allMetrics["scans_completed"].Desc, allMetrics["scans_completed"].Type, float64(data.Completed),
+		sc.metrics["scans_completed"].Desc, sc.metrics["scans_completed"].Type, float64(data.Completed),
 	)
 
 	reportLatency(start, "scans_latency", ch)
-	return true
 }

--- a/metrics_statistics.go
+++ b/metrics_statistics.go
@@ -7,7 +7,28 @@ import (
 	"time"
 )
 
-func (e *HarborExporter) collectStatisticsMetric(ch chan<- prometheus.Metric) bool {
+type StatsCollector struct {
+	exporter *HarborExporter
+	metrics  map[string]metricInfo
+}
+
+func CreateStatsCollector(e *HarborExporter) *StatsCollector {
+	sc := StatsCollector{
+		exporter: e,
+		metrics:  make(map[string]metricInfo),
+	}
+	sc.metrics["repo_count_total"] = newMetricInfo(e.instance, "repo_count_total", "repositories number relevant to the user", prometheus.GaugeValue, typeLabelNames, nil)
+	sc.metrics["project_count_total"] = newMetricInfo(e.instance, "project_count_total", "projects number relevant to the user", prometheus.GaugeValue, typeLabelNames, nil)
+	return &sc
+}
+
+func (sc *StatsCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, m := range sc.metrics {
+		ch <- m.Desc
+	}
+}
+
+func (sc *StatsCollector) Collect(ch chan<- prometheus.Metric) {
 	start := time.Now()
 
 	type statisticsMetric struct {
@@ -19,39 +40,38 @@ func (e *HarborExporter) collectStatisticsMetric(ch chan<- prometheus.Metric) bo
 		Private_repo_count    float64
 	}
 
-	body, _ := e.request("/statistics")
+	body, _ := sc.exporter.request("/statistics")
 
 	var data statisticsMetric
 
 	if err := json.Unmarshal(body, &data); err != nil {
-		level.Error(e.logger).Log(err.Error())
-		return false
+		level.Error(sc.exporter.logger).Log(err.Error())
+		return
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		allMetrics["project_count_total"].Desc, allMetrics["project_count_total"].Type, data.Total_project_count, "total_project",
+		sc.metrics["project_count_total"].Desc, sc.metrics["project_count_total"].Type, data.Total_project_count, "total_project",
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		allMetrics["project_count_total"].Desc, allMetrics["project_count_total"].Type, data.Public_project_count, "public_project",
+		sc.metrics["project_count_total"].Desc, sc.metrics["project_count_total"].Type, data.Public_project_count, "public_project",
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		allMetrics["project_count_total"].Desc, allMetrics["project_count_total"].Type, data.Private_project_count, "private_project",
+		sc.metrics["project_count_total"].Desc, sc.metrics["project_count_total"].Type, data.Private_project_count, "private_project",
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		allMetrics["repo_count_total"].Desc, allMetrics["repo_count_total"].Type, data.Public_repo_count, "public_repo",
+		sc.metrics["repo_count_total"].Desc, sc.metrics["repo_count_total"].Type, data.Public_repo_count, "public_repo",
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		allMetrics["repo_count_total"].Desc, allMetrics["repo_count_total"].Type, data.Total_repo_count, "total_repo",
+		sc.metrics["repo_count_total"].Desc, sc.metrics["repo_count_total"].Type, data.Total_repo_count, "total_repo",
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		allMetrics["repo_count_total"].Desc, allMetrics["repo_count_total"].Type, data.Private_repo_count, "private_repo",
+		sc.metrics["repo_count_total"].Desc, sc.metrics["repo_count_total"].Type, data.Private_repo_count, "private_repo",
 	)
 
 	reportLatency(start, "statistics_latency", ch)
-	return true
 }

--- a/metrics_statistics.go
+++ b/metrics_statistics.go
@@ -46,6 +46,7 @@ func (sc *StatsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := json.Unmarshal(body, &data); err != nil {
 		level.Error(sc.exporter.logger).Log(err.Error())
+		sc.exporter.statsChan <- false
 		return
 	}
 
@@ -72,6 +73,6 @@ func (sc *StatsCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		sc.metrics["repo_count_total"].Desc, sc.metrics["repo_count_total"].Type, data.Private_repo_count, "private_repo",
 	)
-
 	reportLatency(start, "statistics_latency", ch)
+	sc.exporter.statsChan <- true
 }

--- a/metrics_systemvolumes.go
+++ b/metrics_systemvolumes.go
@@ -39,6 +39,7 @@ func (vc *VolumeCollector) Collect(ch chan<- prometheus.Metric) {
 	var data systemVolumesMetric
 	if err := json.Unmarshal(body, &data); err != nil {
 		level.Error(vc.exporter.logger).Log(err.Error())
+		vc.exporter.volumeChan <- false
 		return
 	}
 
@@ -48,6 +49,6 @@ func (vc *VolumeCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		vc.metrics["system_volumes_bytes"].Desc, vc.metrics["system_volumes_bytes"].Type, data.Storage.Free, "free",
 	)
-
 	reportLatency(start, "system_volumes_latency", ch)
+	vc.exporter.volumeChan <- true
 }

--- a/metrics_systemvolumes.go
+++ b/metrics_systemvolumes.go
@@ -10,12 +10,14 @@ import (
 type VolumeCollector struct {
 	exporter *HarborExporter
 	metrics  map[string]metricInfo
+	cache    *Cache
 }
 
 func CreateVolumeCollector(e *HarborExporter) *VolumeCollector {
 	vc := VolumeCollector{
 		exporter: e,
 		metrics:  make(map[string]metricInfo),
+		cache:    NewCache(cacheEnabled, cacheDuration),
 	}
 	vc.metrics["system_volumes_bytes"] = newMetricInfo(e.instance, "system_volumes_bytes", "Get system volume info (total/free size).", prometheus.GaugeValue, storageLabelNames, nil)
 	return &vc
@@ -29,6 +31,15 @@ func (vc *VolumeCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (vc *VolumeCollector) Collect(ch chan<- prometheus.Metric) {
 	start := time.Now()
+	if vc.cache.ReplayMetrics(ch) {
+		vc.exporter.volumeChan <- true
+		return
+	}
+	samplesCh, wg := vc.cache.StoreAndForwaredMetrics(ch)
+	defer func() {
+		close(samplesCh)
+		wg.Wait()
+	}()
 	type systemVolumesMetric struct {
 		Storage struct {
 			Total float64
@@ -43,10 +54,10 @@ func (vc *VolumeCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	ch <- prometheus.MustNewConstMetric(
+	samplesCh <- prometheus.MustNewConstMetric(
 		vc.metrics["system_volumes_bytes"].Desc, vc.metrics["system_volumes_bytes"].Type, data.Storage.Total, "total",
 	)
-	ch <- prometheus.MustNewConstMetric(
+	samplesCh <- prometheus.MustNewConstMetric(
 		vc.metrics["system_volumes_bytes"].Desc, vc.metrics["system_volumes_bytes"].Type, data.Storage.Free, "free",
 	)
 	reportLatency(start, "system_volumes_latency", ch)


### PR DESCRIPTION
When multiple Collectors are registered Prometheus will manage a
threadpool to invoke each Collector in parallel, reducing latency to
fetch all metrics

Add channels from the new Collectors back to HarborExporter to report
whether metrics were successfully gathered, allowing the `up` metric to
be determined

Add cache to each Collector. Collectors will write a result to HarborExporter even when cached data
will be reported to avoid deadlocks when only some Collectors return
cached data
