### PR TITLE
Make caching configurable via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ _Note: when the harbor.instance flag is used, each metric name starts with `harb
 ```
 ./harbor_exporter --cache.enabled --cache.duration 30s
 ```
+This can also be configured via the environment variables `HARBOR_CACHE_ENABLED` and `HARBOR_CACHE_DURATION`.
 
 ---
 `harbor.pagesize` - Set page size for results. Can be also set with Environment variable `HARBOR_PAGESIZE`
@@ -94,6 +95,8 @@ HARBOR_INSTANCE
 HARBOR_URI
 HARBOR_USERNAME
 HARBOR_PASSWORD
+HARBOR_CACHE_ENABLED
+HARBOR_CACHE_DURATION
 ```
 
 ## Using Docker

--- a/harbor_exporter.go
+++ b/harbor_exporter.go
@@ -408,8 +408,8 @@ func main() {
 	kingpin.Flag("harbor.insecure", "Disable TLS host verification.").Default("false").BoolVar(&exporter.insecure)
 	kingpin.Flag("harbor.pagesize", "Page size on requests to the harbor API.").Envar("HARBOR_PAGESIZE").Default("100").IntVar(&exporter.pageSize)
 	skip := kingpin.Flag("skip.metrics", "Skip these metrics groups").Enums(MetricsGroup_Values()...)
-	kingpin.Flag("cache.enabled", "Enable metrics caching.").Default("false").BoolVar(&exporter.cacheEnabled)
-	kingpin.Flag("cache.duration", "Time duration collected values are cached for.").Default("20s").DurationVar(&exporter.cacheDuration)
+	kingpin.Flag("cache.enabled", "Enable metrics caching.").Envar("HARBOR_CACHE_ENABLED").Default("false").BoolVar(&exporter.cacheEnabled)
+	kingpin.Flag("cache.duration", "Time duration collected values are cached for.").Envar("HARBOR_CACHE_DURATION").Default("20s").DurationVar(&exporter.cacheDuration)
 
 	promlogConfig := &promlog.Config{}
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)

--- a/kubernetes/harbor-exporter.yaml
+++ b/kubernetes/harbor-exporter.yaml
@@ -61,6 +61,11 @@ spec:
 #                configMapKeyRef:
 #                  name: prefix-harbor-core # change prefix to the name of your Helm release
 #                  key: EXT_ENDPOINT
+##          uncomment if you want to use caching
+#           - name: HARBOR_CACHE_ENABLED
+#             value: "true"
+#           - name: HARBOR_CACHE_DURATION
+#             value: "20s"
             - name: HARBOR_USERNAME
               value: "admin"
             - name: HARBOR_PASSWORD


### PR DESCRIPTION
This PR adds the possibility to configure caching via environment variables. This way we don't have two places for configuration parameters when using a docker container.

Fixes https://github.com/c4po/harbor_exporter/issues/63