### PR TITLE
Added artifacts metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ make dockerbuild
 |harbor_system_with_chartmuseum   | |
 |harbor_system_notification_enable| |                              
 |harbor_replication_latency| | |
+|harbor_artifacts_vulnerabilities|quantity of detected vulnerabilities|artifact_id, artifact_name, project_id, project_name, repo_id, repo_name, report_id, status=[fixable, total, fixable, low, medium, high]|
+|harbor_artifacts_size|size in bytes|artifact_id, artifact_name, project_id, project_name, repo_id, repo_name|
+|harbor_artifacts_vulnerabilities_scans|current status of scan process: 1 - Success, 2 - Running, 0 - other|artifact_id, artifact_name, project_id, project_name, repo_id, repo_name, status|
+|harbor_artifacts_vulnerabilities_scan_duration|time spent on the last scan|artifact_id, artifact_name, project_id, project_name, repo_id, repo_name, report_id|
+|harbor_artifacts_vulnerabilities_scan_start|the last scan start timestamp|artifact_id, artifact_name, project_id, project_name, repo_id, repo_name, report_id|
+
 
 _Note: when the harbor.instance flag is used, each metric name starts with `harbor_instancename_` instead of just `harbor_`._
 

--- a/harbor_exporter.go
+++ b/harbor_exporter.go
@@ -41,13 +41,14 @@ const (
 	namespace = "harbor"
 
 	//These are metricsGroup enum values
-	metricsGroupHealth       = "health"
-	metricsGroupScans        = "scans"
-	metricsGroupStatistics   = "statistics"
-	metricsGroupQuotas       = "quotas"
-	metricsGroupRepositories = "repositories"
-	metricsGroupReplication  = "replication"
-	metricsGroupSystemInfo   = "systeminfo"
+	metricsGroupHealth        = "health"
+	metricsGroupScans         = "scans"
+	metricsGroupStatistics    = "statistics"
+	metricsGroupQuotas        = "quotas"
+	metricsGroupRepositories  = "repositories"
+	metricsGroupReplication   = "replication"
+	metricsGroupSystemInfo    = "systeminfo"
+	metricsGroupArtifactsInfo = "artifacts"
 )
 
 func metricsGroupValues() []string {
@@ -59,6 +60,7 @@ func metricsGroupValues() []string {
 		metricsGroupRepositories,
 		metricsGroupReplication,
 		metricsGroupSystemInfo,
+		metricsGroupArtifactsInfo,
 	}
 }
 
@@ -66,14 +68,17 @@ var (
 	allMetrics          map[string]metricInfo
 	collectMetricsGroup map[string]bool
 
-	componentLabelNames       = []string{"component"}
-	typeLabelNames            = []string{"type"}
-	quotaLabelNames           = []string{"type", "repo_name", "repo_id"}
-	repoLabelNames            = []string{"repo_name", "repo_id"}
-	storageLabelNames         = []string{"storage"}
-	replicationLabelNames     = []string{"repl_pol_name"}
-	replicationTaskLabelNames = []string{"repl_pol_name", "result"}
-	systemInfoLabelNames      = []string{"auth_mode", "project_creation_restriction", "harbor_version", "registry_storage_provider_name"}
+	componentLabelNames                     = []string{"component"}
+	typeLabelNames                          = []string{"type"}
+	quotaLabelNames                         = []string{"type", "repo_name", "repo_id"}
+	repoLabelNames                          = []string{"repo_name", "repo_id"}
+	artifactLabelNames                      = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id"}
+	artifactVulnerabilitiesLabelNames       = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id", "report_id", "status"}
+	artifactsVulnerabilitiesScansLabelNames = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id"}
+	storageLabelNames                       = []string{"storage"}
+	replicationLabelNames                   = []string{"repl_pol_name"}
+	replicationTaskLabelNames               = []string{"repl_pol_name", "result"}
+	systemInfoLabelNames                    = []string{"auth_mode", "project_creation_restriction", "harbor_version", "registry_storage_provider_name"}
 )
 
 type metricInfo struct {
@@ -116,6 +121,12 @@ func createMetrics(instanceName string) {
 	allMetrics["repositories_star_total"] = newMetricInfo(instanceName, "repositories_star_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
 	allMetrics["repositories_tags_total"] = newMetricInfo(instanceName, "repositories_tags_total", "Get public repositories which are accessed most.).", prometheus.GaugeValue, repoLabelNames, nil)
 	allMetrics["repositories_latency"] = newMetricInfo(instanceName, "repositories_latency", "Time in seconds to collect repository metrics", prometheus.GaugeValue, nil, nil)
+	allMetrics["artifacts_size"] = newMetricInfo(instanceName, "artifacts_size", "Size in bytes for uploaded artifacts", prometheus.GaugeValue, artifactLabelNames, nil)
+	allMetrics["artifacts_vulnerabilities"] = newMetricInfo(instanceName, "artifacts_vulnerabilities", "Detected vulnerabilities for uploaded artifacts", prometheus.GaugeValue, artifactVulnerabilitiesLabelNames, nil)
+	allMetrics["artifacts_vulnerabilities_scan_start"] = newMetricInfo(instanceName, "artifacts_vulnerabilities_scan_start", "Vulnerabilities scan start time", prometheus.GaugeValue, artifactVulnerabilitiesLabelNames, nil)
+	allMetrics["artifacts_vulnerabilities_scan_duration"] = newMetricInfo(instanceName, "artifacts_vulnerabilities_scan_duration", "Vulnerabilities scan duration", prometheus.GaugeValue, artifactVulnerabilitiesLabelNames, nil)
+	allMetrics["artifacts_vulnerabilities_scans"] = newMetricInfo(instanceName, "artifacts_vulnerabilities_scans", "Vulnerabilities scan operation status. Success == 1, running == 2; others == 0", prometheus.CounterValue, artifactsVulnerabilitiesScansLabelNames, nil)
+	allMetrics["artifacts_latency"] = newMetricInfo(instanceName, "artifacts_latency", "Time in seconds to collect artifacts metrics", prometheus.GaugeValue, nil, nil)
 	allMetrics["replication_status"] = newMetricInfo(instanceName, "replication_status", "Get status of the last execution of this replication policy: Succeed = 1, any other status = 0.", prometheus.GaugeValue, replicationLabelNames, nil)
 	allMetrics["replication_tasks"] = newMetricInfo(instanceName, "replication_tasks", "Get number of replication tasks, with various results, in the latest execution of this replication policy.", prometheus.GaugeValue, replicationTaskLabelNames, nil)
 	allMetrics["system_info"] = newMetricInfo(instanceName, "system_info", "A metric with a constant '1' value labeled by auth_mode, project_creation_restriction, harbor_version and registry_storage_provider_name from /systeminfo endpoint.", prometheus.GaugeValue, systemInfoLabelNames, nil)
@@ -361,6 +372,9 @@ func (h *HarborExporter) Collect(outCh chan<- prometheus.Metric) {
 	}
 	if collectMetricsGroup[metricsGroupSystemInfo] {
 		ok = h.collectSystemMetric(samplesCh)
+	}
+	if collectMetricsGroup[metricsGroupArtifactsInfo] {
+		ok = h.collectArtifactsMetric(samplesCh) && ok
 	}
 
 	if ok {

--- a/harbor_exporter.go
+++ b/harbor_exporter.go
@@ -68,17 +68,18 @@ var (
 	allMetrics          map[string]metricInfo
 	collectMetricsGroup map[string]bool
 
-	componentLabelNames                     = []string{"component"}
-	typeLabelNames                          = []string{"type"}
-	quotaLabelNames                         = []string{"type", "repo_name", "repo_id"}
-	repoLabelNames                          = []string{"repo_name", "repo_id"}
-	artifactLabelNames                      = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id"}
-	artifactVulnerabilitiesLabelNames       = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id", "report_id", "status"}
-	artifactsVulnerabilitiesScansLabelNames = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id"}
-	storageLabelNames                       = []string{"storage"}
-	replicationLabelNames                   = []string{"repl_pol_name"}
-	replicationTaskLabelNames               = []string{"repl_pol_name", "result"}
-	systemInfoLabelNames                    = []string{"auth_mode", "project_creation_restriction", "harbor_version", "registry_storage_provider_name"}
+	componentLabelNames                       = []string{"component"}
+	typeLabelNames                            = []string{"type"}
+	quotaLabelNames                           = []string{"type", "repo_name", "repo_id"}
+	repoLabelNames                            = []string{"repo_name", "repo_id"}
+	artifactLabelNames                        = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id"}
+	artifactVulnerabilitiesLabelNames         = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id", "report_id", "status"}
+	artifactsVulnerabilitiesScansLabelNames   = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id"}
+	artifactVulnerabilitiesDurationLabelNames = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id", "report_id"}
+	storageLabelNames                         = []string{"storage"}
+	replicationLabelNames                     = []string{"repl_pol_name"}
+	replicationTaskLabelNames                 = []string{"repl_pol_name", "result"}
+	systemInfoLabelNames                      = []string{"auth_mode", "project_creation_restriction", "harbor_version", "registry_storage_provider_name"}
 )
 
 type metricInfo struct {
@@ -123,8 +124,8 @@ func createMetrics(instanceName string) {
 	allMetrics["repositories_latency"] = newMetricInfo(instanceName, "repositories_latency", "Time in seconds to collect repository metrics", prometheus.GaugeValue, nil, nil)
 	allMetrics["artifacts_size"] = newMetricInfo(instanceName, "artifacts_size", "Size in bytes for uploaded artifacts", prometheus.GaugeValue, artifactLabelNames, nil)
 	allMetrics["artifacts_vulnerabilities"] = newMetricInfo(instanceName, "artifacts_vulnerabilities", "Detected vulnerabilities for uploaded artifacts", prometheus.GaugeValue, artifactVulnerabilitiesLabelNames, nil)
-	allMetrics["artifacts_vulnerabilities_scan_start"] = newMetricInfo(instanceName, "artifacts_vulnerabilities_scan_start", "Vulnerabilities scan start time", prometheus.GaugeValue, artifactVulnerabilitiesLabelNames, nil)
-	allMetrics["artifacts_vulnerabilities_scan_duration"] = newMetricInfo(instanceName, "artifacts_vulnerabilities_scan_duration", "Vulnerabilities scan duration", prometheus.GaugeValue, artifactVulnerabilitiesLabelNames, nil)
+	allMetrics["artifacts_vulnerabilities_scan_start"] = newMetricInfo(instanceName, "artifacts_vulnerabilities_scan_start", "Vulnerabilities scan start time", prometheus.GaugeValue, artifactVulnerabilitiesDurationLabelNames, nil)
+	allMetrics["artifacts_vulnerabilities_scan_duration"] = newMetricInfo(instanceName, "artifacts_vulnerabilities_scan_duration", "Vulnerabilities scan duration", prometheus.GaugeValue, artifactVulnerabilitiesDurationLabelNames, nil)
 	allMetrics["artifacts_vulnerabilities_scans"] = newMetricInfo(instanceName, "artifacts_vulnerabilities_scans", "Vulnerabilities scan operation status. Success == 1, running == 2; others == 0", prometheus.CounterValue, artifactsVulnerabilitiesScansLabelNames, nil)
 	allMetrics["artifacts_latency"] = newMetricInfo(instanceName, "artifacts_latency", "Time in seconds to collect artifacts metrics", prometheus.GaugeValue, nil, nil)
 	allMetrics["replication_status"] = newMetricInfo(instanceName, "replication_status", "Get status of the last execution of this replication policy: Succeed = 1, any other status = 0.", prometheus.GaugeValue, replicationLabelNames, nil)

--- a/metric_artifacts.go
+++ b/metric_artifacts.go
@@ -89,10 +89,11 @@ func (h *HarborExporter) collectArtifactsMetric(ch chan<- prometheus.Metric) boo
 
 	// Make metrics.
 	var (
-		sizeMI     = allMetrics["artifacts_size"]
-		vulnMI     = allMetrics["artifacts_vulnerabilities"]
-		scansMI    = allMetrics["artifacts_vulnerabilities_scans"]
-		scansDurMI = allMetrics["artifacts_vulnerabilities_scan_duration"]
+		sizeMI       = allMetrics["artifacts_size"]
+		vulnMI       = allMetrics["artifacts_vulnerabilities"]
+		scansMI      = allMetrics["artifacts_vulnerabilities_scans"]
+		scansDurMI   = allMetrics["artifacts_vulnerabilities_scan_duration"]
+		scansStartTS = allMetrics["artifacts_vulnerabilities_scan_start"]
 	)
 
 	for pi := range prData {
@@ -139,8 +140,8 @@ func (h *HarborExporter) collectArtifactsMetric(ch chan<- prometheus.Metric) boo
 				ch <- prometheus.MustNewConstMetric(vulnMI.Desc, vulnMI.Type, float64(scanInfo.Summary.Summary.High), projectName, projectID, repoName, repoID, artName, artID, reportID, "high")
 
 				// Scan Status.
-				ch <- prometheus.MustNewConstMetric(scansDurMI.Desc, scansDurMI.Type, float64(scanInfo.Duration), projectName, projectID, repoName, repoID, artName, artID, reportID, "duration_sec")
-				ch <- prometheus.MustNewConstMetric(scansDurMI.Desc, scansDurMI.Type, float64(scanInfo.StartTime.Unix()), projectName, projectID, repoName, repoID, artName, artID, reportID, "start_time")
+				ch <- prometheus.MustNewConstMetric(scansDurMI.Desc, scansDurMI.Type, float64(scanInfo.Duration), projectName, projectID, repoName, repoID, artName, artID, reportID)
+				ch <- prometheus.MustNewConstMetric(scansStartTS.Desc, scansStartTS.Type, float64(scanInfo.StartTime.Unix()), projectName, projectID, repoName, repoID, artName, artID, reportID)
 
 				var scanRes float64
 

--- a/metric_artifacts.go
+++ b/metric_artifacts.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type project struct {
+	ProjectID int64  `json:"project_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+
+	repositories repositories
+}
+
+type projects []project
+
+type repository struct {
+	ID   int64  `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+
+	artifacts artifacts
+}
+
+type repositories []repository
+
+type scanOverview struct {
+	Duration   int       `json:"duration"`
+	EndTime    time.Time `json:"end_time"`
+	ReportID   string    `json:"report_id"`
+	ScanStatus string    `json:"scan_status"`
+	Severity   string    `json:"severity"`
+	StartTime  time.Time `json:"start_time"`
+	Summary    struct {
+		Fixable int `json:"fixable"`
+		Summary struct {
+			High   int `json:"High"`
+			Low    int `json:"Low"`
+			Medium int `json:"Medium"`
+		} `json:"summary"`
+		Total int `json:"total"`
+	} `json:"summary"`
+}
+
+type artifact struct {
+	Digest       string       `json:"digest"`
+	ID           int64        `json:"id"`
+	ProjectID    int64        `json:"project_id"`
+	RepositoryID int64        `json:"repository_id"`
+	ScanOverview scanOverview `json:"scan_overview"`
+	Size         int64        `json:"size"`
+	Tags         []struct {
+		ArtifactID   int64  `json:"artifact_id"`
+		ID           int64  `json:"id"`
+		Immutable    bool   `json:"immutable"`
+		Name         string `json:"name"`
+		RepositoryID int64  `json:"repository_id"`
+		Signed       bool   `json:"signed"`
+	} `json:"tags"`
+	Type string `json:"type"`
+}
+
+type artifacts []artifact
+
+func (h *HarborExporter) collectArtifactsMetric(ch chan<- prometheus.Metric) bool {
+	// Do not load V1 API.
+	// ToDo: Implement V1 support.
+	if !h.isV2 {
+		return true
+	}
+
+	start := time.Now()
+
+	// Load Projects.
+	prData, err := h.loadProjects()
+	if err != nil {
+		return false
+	}
+
+	// Load Repositories.
+	prData, err = h.loadRepositories(prData)
+	if err != nil {
+		return false
+	}
+
+	// Make metrics.
+	var (
+		sizeMI     = allMetrics["artifacts_size"]
+		vulnMI     = allMetrics["artifacts_vulnerabilities"]
+		scansMI    = allMetrics["artifacts_vulnerabilities_scans"]
+		scansDurMI = allMetrics["artifacts_vulnerabilities_scan_duration"]
+	)
+
+	for pi := range prData {
+		var (
+			pp = &prData[pi]
+
+			projectName = pp.Name
+			projectID   = strconv.FormatInt(pp.ProjectID, 10)
+		)
+
+		for ri := range pp.repositories {
+			var (
+				rp = &pp.repositories[ri]
+
+				repoName = rp.Name
+				repoID   = strconv.FormatInt(rp.ID, 10)
+			)
+
+			for ai := range rp.artifacts {
+				var (
+					ap = &rp.artifacts[ai]
+
+					artID   = strconv.FormatInt(ap.ID, 10)
+					artName = ap.Digest
+				)
+
+				// Size.
+				ch <- prometheus.MustNewConstMetric(sizeMI.Desc, sizeMI.Type, float64(ap.Size), projectName, projectID, repoName, repoID, artName, artID)
+
+				// Vulnerabilities.
+				var scanInfo = &ap.ScanOverview
+
+				// No scan performed.
+				var reportID = scanInfo.ReportID
+
+				if reportID == "" {
+					continue
+				}
+
+				ch <- prometheus.MustNewConstMetric(vulnMI.Desc, vulnMI.Type, float64(scanInfo.Summary.Fixable), projectName, projectID, repoName, repoID, artName, artID, reportID, "fixable")
+				ch <- prometheus.MustNewConstMetric(vulnMI.Desc, vulnMI.Type, float64(scanInfo.Summary.Total), projectName, projectID, repoName, repoID, artName, artID, reportID, "total")
+				ch <- prometheus.MustNewConstMetric(vulnMI.Desc, vulnMI.Type, float64(scanInfo.Summary.Summary.Low), projectName, projectID, repoName, repoID, artName, artID, reportID, "low")
+				ch <- prometheus.MustNewConstMetric(vulnMI.Desc, vulnMI.Type, float64(scanInfo.Summary.Summary.Medium), projectName, projectID, repoName, repoID, artName, artID, reportID, "medium")
+				ch <- prometheus.MustNewConstMetric(vulnMI.Desc, vulnMI.Type, float64(scanInfo.Summary.Summary.High), projectName, projectID, repoName, repoID, artName, artID, reportID, "high")
+
+				// Scan Status.
+				ch <- prometheus.MustNewConstMetric(scansDurMI.Desc, scansDurMI.Type, float64(scanInfo.Duration), projectName, projectID, repoName, repoID, artName, artID, reportID, "duration_sec")
+				ch <- prometheus.MustNewConstMetric(scansDurMI.Desc, scansDurMI.Type, float64(scanInfo.StartTime.Unix()), projectName, projectID, repoName, repoID, artName, artID, reportID, "start_time")
+
+				var scanRes float64
+
+				switch strings.ToLower(scanInfo.ScanStatus) {
+				case "success":
+					scanRes = 1
+				case "running":
+					scanRes = 2
+				}
+
+				ch <- prometheus.MustNewConstMetric(scansMI.Desc, scansMI.Type, scanRes, projectName, projectID, repoName, repoID, artName, artID)
+			}
+		}
+	}
+
+	reportLatency(start, "artifacts_latency", ch)
+
+	return true
+}
+
+func (h *HarborExporter) loadProjects() (projects, error) {
+	// Load Projects.
+	var projectsData projects
+
+	err := h.requestAll("/projects", func(pageBody []byte) error {
+		var pageData projects
+		if err := json.Unmarshal(pageBody, &pageData); err != nil {
+			return err
+		}
+
+		projectsData = append(projectsData, pageData...)
+
+		return nil
+	})
+	if err != nil {
+		level.Error(h.logger).Log(err.Error())
+
+		return nil, err
+	}
+
+	return projectsData, nil
+}
+
+func (h *HarborExporter) loadRepositories(projectsData projects) (projects, error) {
+	// Load Repositories for Projects.
+	for i := range projectsData {
+		projectID := strconv.FormatInt(projectsData[i].ProjectID, 10)
+
+		var reqURL string
+		if h.isV2 {
+			reqURL = "/projects/" + projectsData[i].Name + "/repositories"
+		} else {
+			reqURL = "/repositories?project_id=" + projectID
+		}
+
+		var pageData repositories
+		err := h.requestAll(reqURL, func(pageBody []byte) error {
+			if err := json.Unmarshal(pageBody, &pageData); err != nil {
+				return err
+			}
+
+			return nil
+		})
+		if err != nil {
+			level.Error(h.logger).Log(err.Error())
+
+			return nil, err
+		}
+
+		// Load Artifacts for Repositories.
+		af, err := h.loadArtifacts(projectsData[i].Name, pageData)
+		if err != nil {
+			level.Error(h.logger).Log(err.Error())
+
+			return nil, err
+		}
+
+		// Save.
+		projectsData[i].repositories = af
+	}
+
+	return projectsData, nil
+}
+
+func (h *HarborExporter) loadArtifacts(projectName string, repoData repositories) (repositories, error) {
+	type rawArtifacts []struct {
+		Digest       string                  `json:"digest"`
+		ID           int64                   `json:"id"`
+		ProjectID    int64                   `json:"project_id"`
+		RepositoryID int64                   `json:"repository_id"`
+		ScanOverview map[string]scanOverview `json:"scan_overview"`
+		Size         int64                   `json:"size"`
+		Tags         []struct {
+			ArtifactID   int64  `json:"artifact_id"`
+			ID           int64  `json:"id"`
+			Immutable    bool   `json:"immutable"`
+			Name         string `json:"name"`
+			RepositoryID int64  `json:"repository_id"`
+			Signed       bool   `json:"signed"`
+		} `json:"tags"`
+		Type string `json:"type"`
+	}
+
+	for i := range repoData {
+		var reqURL string
+		if h.isV2 {
+			reqURL = "/projects/" + projectName +
+				"/repositories" + strings.TrimLeft(repoData[i].Name, projectName) +
+				"/artifacts?with_tag=true&with_scan_overview=true"
+		} else {
+			panic("No v1 API support")
+		}
+
+		if err := h.requestAll(reqURL, func(b []byte) error {
+			var pageData rawArtifacts
+
+			if err := json.Unmarshal(b, &pageData); err != nil {
+				return err
+			}
+
+			// Convert.
+			var repoArts artifacts
+
+			for pi := range pageData {
+				pp := &pageData[pi]
+
+				// Parse Scan Overview Convert.
+				var parsedScanOverview scanOverview
+
+				for _, v := range pp.ScanOverview {
+					parsedScanOverview = v
+
+					break
+				}
+
+				repoArts = append(repoArts, artifact{
+					Digest:       pp.Digest,
+					ID:           pp.ID,
+					ProjectID:    pp.ProjectID,
+					RepositoryID: pp.RepositoryID,
+					Size:         pp.Size,
+					Tags:         pp.Tags,
+					Type:         pp.Type,
+					ScanOverview: parsedScanOverview,
+				})
+			}
+
+			repoData[i].artifacts = repoArts
+
+			return nil
+		}); err != nil {
+			level.Error(h.logger).Log(err.Error())
+
+			return nil, err
+		}
+	}
+
+	return repoData, nil
+}


### PR DESCRIPTION
The pull request implements metrics for Registry artifacts:

- harbor_artifacts_vulnerabilities - total, fixable, low, medium, high
- harbor_artifacts_size - in bytes
- harbor_artifacts_vulnerabilities_scans - current status of scan process: 1 - Success, 2 - Running, 0 - other.
- harbor_artifacts_vulnerabilities_scan_duration - start timestamp, duration.

For now, the artifacts are identified by their SHA256 hash, project and repository names, for example:

```
harbor_artifacts_vulnerabilities{artifact_id="1",artifact_name="sha256:11bf4d13d81ef582401928b85aa2e325719b125821a578c656451f43d41716be",instance="localhost:9107",job="harbor-exporter",project_id="3",project_name="test-images",repo_id="1",repo_name="test-images/test-image",report_id="1efe2c87-a505-4d70-9c13-03e0b05e8ce5",status="fixable"}
```

