### PR TITLE
Fix missing replication metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ make dockerbuild
 |harbor_repositories_star_total| |repo_id, repo_name|
 |harbor_repositories_tags_total| |repo_id, repo_name|
 |harbor_repositories_latency| | |
-|harbor_replication_status|status of the last execution of this replication policy: Succeed = 1, any other status = 0|repl_pol_name|
-|harbor_replication_tasks|number of replication tasks, with various results, in the latest execution of this replication policy|repl_pol_name, result=[failed, succeed, in_progress, stopped]|
+|harbor_replication_status|status of the last execution of this replication policy: Succeed = 1, any other status = 0|repl_pol_name, repl_trigger_type[manual, scheduled, event_based]|
+|harbor_replication_tasks|number of replication tasks, with various results, in the latest execution of this replication policy|repl_pol_name, repl_trigger_type[manual, scheduled, event_based], result=[failed, succeed, in_progress, stopped]|
 |harbor_system_info               | |auth_mode, project_creation_restriction, harbor_version, registry_storage_provider_name
 |harbor_system_with_notary        | |
 |harbor_system_self_registration  | |

--- a/harbor_exporter.go
+++ b/harbor_exporter.go
@@ -77,8 +77,8 @@ var (
 	artifactsVulnerabilitiesScansLabelNames   = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id", "tag"}
 	artifactVulnerabilitiesDurationLabelNames = []string{"project_name", "project_id", "repo_name", "repo_id", "artifact_name", "artifact_id", "report_id", "tag"}
 	storageLabelNames                         = []string{"storage"}
-	replicationLabelNames                     = []string{"repl_pol_name"}
-	replicationTaskLabelNames                 = []string{"repl_pol_name", "result"}
+	replicationLabelNames                     = []string{"repl_pol_name", "repl_trigger_type"}
+	replicationTaskLabelNames                 = []string{"repl_pol_name", "repl_trigger_type", "result"}
 	systemInfoLabelNames                      = []string{"auth_mode", "project_creation_restriction", "harbor_version", "registry_storage_provider_name"}
 )
 

--- a/metrics_replications.go
+++ b/metrics_replications.go
@@ -45,7 +45,7 @@ func (h *HarborExporter) collectReplicationsMetric(ch chan<- prometheus.Metric) 
 	}
 
 	for i := range policiesData {
-		if policiesData[i].Enabled == true && policiesData[i].Trigger.Type == "scheduled" {
+		if policiesData[i].Enabled == true {
 			policyID := strconv.FormatFloat(policiesData[i].ID, 'f', 0, 32)
 			policyName := policiesData[i].Name
 
@@ -59,11 +59,11 @@ func (h *HarborExporter) collectReplicationsMetric(ch chan<- prometheus.Metric) 
 
 			if len(data) == 0 {
 				level.Debug(h.logger).Log("msg", "Policy "+policyName+" (ID "+policyID+") has no executions yet")
-				return false
+				continue
 			}
 
 			var j int = 0
-			if data[j].Status == "InProgress" && len(data) > 1 {
+			if len(data) > 1 && data[j].Status == "InProgress" {
 				// Current is in progress: check previous replication execution
 				j = 1
 			}

--- a/metrics_replications.go
+++ b/metrics_replications.go
@@ -48,6 +48,7 @@ func (h *HarborExporter) collectReplicationsMetric(ch chan<- prometheus.Metric) 
 		if policiesData[i].Enabled == true {
 			policyID := strconv.FormatFloat(policiesData[i].ID, 'f', 0, 32)
 			policyName := policiesData[i].Name
+			triggerType := policiesData[i].Trigger.Type
 
 			body, _ := h.request("/replication/executions?policy_id=" + policyID + "&page=1&page_size=2")
 			var data policyMetric
@@ -74,19 +75,19 @@ func (h *HarborExporter) collectReplicationsMetric(ch chan<- prometheus.Metric) 
 				replStatus = 1
 			}
 			ch <- prometheus.MustNewConstMetric(
-				allMetrics["replication_status"].Desc, allMetrics["replication_status"].Type, replStatus, policyName,
+				allMetrics["replication_status"].Desc, allMetrics["replication_status"].Type, replStatus, policyName, triggerType,
 			)
 			ch <- prometheus.MustNewConstMetric(
-				allMetrics["replication_tasks"].Desc, allMetrics["replication_tasks"].Type, data[j].Failed, policyName, "failed",
+				allMetrics["replication_tasks"].Desc, allMetrics["replication_tasks"].Type, data[j].Failed, policyName, triggerType, "failed",
 			)
 			ch <- prometheus.MustNewConstMetric(
-				allMetrics["replication_tasks"].Desc, allMetrics["replication_tasks"].Type, data[j].Succeed, policyName, "succeed",
+				allMetrics["replication_tasks"].Desc, allMetrics["replication_tasks"].Type, data[j].Succeed, policyName, triggerType, "succeed",
 			)
 			ch <- prometheus.MustNewConstMetric(
-				allMetrics["replication_tasks"].Desc, allMetrics["replication_tasks"].Type, data[j].InProgress, policyName, "in_progress",
+				allMetrics["replication_tasks"].Desc, allMetrics["replication_tasks"].Type, data[j].InProgress, policyName, triggerType, "in_progress",
 			)
 			ch <- prometheus.MustNewConstMetric(
-				allMetrics["replication_tasks"].Desc, allMetrics["replication_tasks"].Type, data[j].Stopped, policyName, "stopped",
+				allMetrics["replication_tasks"].Desc, allMetrics["replication_tasks"].Type, data[j].Stopped, policyName, triggerType, "stopped",
 			)
 		}
 	}


### PR DESCRIPTION
Bug-Fix/Features:
- Create replication metrics for each trigger type instead of restricting to scheduled policies (scheduled, manual, event_based)
- Additional label `repl_trigger_type` that allows us to restrict alerts to certain replication trigger types in case we want to test replications with manual replication runs 
- Skip policies where no executions exist instead of exiting the whole function