### PR TITLE
Add json struct tags (fixes #78)

### DIFF
--- a/metrics_quotas.go
+++ b/metrics_quotas.go
@@ -13,21 +13,21 @@ func (h *HarborExporter) collectQuotasMetric(ch chan<- prometheus.Metric) bool {
 	start := time.Now()
 
 	type quotaMetric []struct {
-		ID  float64
+		ID  float64 `json:"id"`
 		Ref struct {
-			ID        float64
-			Name      string
-			OwnerName string
+			ID        float64 `json:"id"`
+			Name      string  `json:"name"`
+			OwnerName string  `json:"owner_name"`
 		}
 		CreationTime time.Time
 		UpdateTime   time.Time
 		Hard         struct {
-			Count   float64
-			Storage float64
+			Count   float64 `json:"count"`
+			Storage float64 `json:"storage"`
 		}
 		Used struct {
-			Count   float64
-			Storage float64
+			Count   float64 `json:"count"`
+			Storage float64 `json:"storage"`
 		}
 	}
 	var data quotaMetric

--- a/metrics_replications.go
+++ b/metrics_replications.go
@@ -12,20 +12,20 @@ import (
 func (h *HarborExporter) collectReplicationsMetric(ch chan<- prometheus.Metric) bool {
 	start := time.Now()
 	type policiesMetrics []struct {
-		ID      float64
-		Name    string
-		Enabled bool
+		ID      float64 `json:"id"`
+		Name    string  `json:"name"`
+		Enabled bool    `json:"enabled"`
 		Trigger struct {
-			Type string
+			Type string `json:"type"`
 		}
 		// Extra fields omitted for maintainability: not relevant for current metrics
 	}
 	type policyMetric []struct {
-		Status     string
-		Failed     float64
-		Succeed    float64
-		InProgress float64
-		Stopped    float64
+		Status     string  `json:"status"`
+		Failed     float64 `json:"failed"`
+		Succeed    float64 `json:"succeed"`
+		InProgress float64 `json:"in_progress"`
+		Stopped    float64 `json:"stopped"`
 		// Extra fields omitted for maintainability: not relevant for current metrics
 	}
 

--- a/metrics_repositories.go
+++ b/metrics_repositories.go
@@ -12,43 +12,43 @@ import (
 func (h *HarborExporter) collectRepositoriesMetric(ch chan<- prometheus.Metric) bool {
 	start := time.Now()
 	type projectsMetrics []struct {
-		ProjectID  float64
-		OwnerID    float64
-		Name       string
-		RepoCount  float64
-		ChartCount float64
+		ProjectID  float64 `json:"project_id"`
+		OwnerID    float64 `json:"owner_id"`
+		Name       string  `json:"name"`
+		RepoCount  float64 `json:"repo_count"`
+		ChartCount float64 `json:"chart_count"`
 	}
 	type repositoriesMetric []struct {
-		ID           float64
-		Name         string
-		ProjectID    float64
-		Description  string
-		PullCount    float64
-		StarCount    float64
-		TagsCount    float64
-		CreationTime time.Time
-		UpdateTime   time.Time
+		ID           float64   `json:"id"`
+		Name         string    `json:"name"`
+		ProjectID    float64   `json:"project_id"`
+		Description  string    `json:"description"`
+		PullCount    float64   `json:"pull_count"`
+		StarCount    float64   `json:"star_count"`
+		TagsCount    float64   `json:"tags_count"`
+		CreationTime time.Time `json:"creation_time"`
+		UpdateTime   time.Time `json:"update_time"`
 		labels       []struct {
-			ID           float64
-			Name         string
-			ProjectID    float64
-			Description  string
-			Color        string
-			Deleted      bool
-			Scope        string
-			CreationTime time.Time
-			UpdateTime   time.Time
+			ID           float64   `json:"id"`
+			Name         string    `json:"name"`
+			ProjectID    float64   `json:"project_id"`
+			Description  string    `json:"description"`
+			Color        string    `json:"color"`
+			Deleted      bool      `json:"deleted"`
+			Scope        string    `json:"scope"`
+			CreationTime time.Time `json:"creation_time"`
+			UpdateTime   time.Time `json:"update_time"`
 		}
 	}
 	type repositoriesMetricV2 []struct {
-		ID            float64
-		Name          string
-		ProjectID     float64
-		Description   string
-		PullCount     float64
-		ArtifactCount float64
-		CreationTime  time.Time
-		UpdateTime    time.Time
+		ID            float64   `json:"id"`
+		Name          string    `json:"name"`
+		ProjectID     float64   `json:"project_id"`
+		Description   string    `json:"description"`
+		PullCount     float64   `json:"pull_count"`
+		ArtifactCount float64   `json:"artifact_count"`
+		CreationTime  time.Time `json:"creation_time"`
+		UpdateTime    time.Time `json:"update_time"`
 	}
 	var projectsData projectsMetrics
 	err := h.requestAll("/projects", func(pageBody []byte) error {

--- a/metrics_statistics.go
+++ b/metrics_statistics.go
@@ -12,12 +12,12 @@ func (h *HarborExporter) collectStatisticsMetric(ch chan<- prometheus.Metric) bo
 	start := time.Now()
 
 	type statisticsMetric struct {
-		TotalProjectCount   float64
-		PublicProjectCount  float64
-		PrivateProjectCount float64
-		PublicRepoCount     float64
-		TotalRepoCount      float64
-		PrivateRepoCount    float64
+		TotalProjectCount   float64 `json:"total_project_count"`
+		PublicProjectCount  float64 `json:"public_project_count"`
+		PrivateProjectCount float64 `json:"private_project_count"`
+		PublicRepoCount     float64 `json:"public_repo_count"`
+		TotalRepoCount      float64 `json:"total_repo_count"`
+		PrivateRepoCount    float64 `json:"private_repo_count"`
 	}
 
 	body, _ := h.request("/statistics")


### PR DESCRIPTION
With https://github.com/c4po/harbor_exporter/pull/73  a couple of metrics got broken, because the keys of the json no longer matched the keys in the struct.

This MR adds the required struct tags to make it work again.

Fixes https://github.com/c4po/harbor_exporter/issues/78