### PR TITLE
Fix: Exporter could report success eventhough metrics are missing

### DIFF
--- a/harbor_exporter.go
+++ b/harbor_exporter.go
@@ -372,7 +372,7 @@ func (h *HarborExporter) Collect(outCh chan<- prometheus.Metric) {
 		ok = h.collectReplicationsMetric(samplesCh) && ok
 	}
 	if collectMetricsGroup[metricsGroupSystemInfo] {
-		ok = h.collectSystemMetric(samplesCh)
+		ok = h.collectSystemMetric(samplesCh) && ok
 	}
 	if collectMetricsGroup[metricsGroupArtifactsInfo] {
 		ok = h.collectArtifactsMetric(samplesCh) && ok


### PR DESCRIPTION
Hey.

When browsing the code I saw this supposedly obvious oversight. It would cause the exporter to report a successful export event if some metrics failed.